### PR TITLE
return the result of statsd.timer

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,14 @@ sections of code with the ``timer()`` method::
 When the managed block exits, the client will automatically send the time it
 took to statsd.
 
+If you'd like to catpure the elapsed time, add a variable to the ``with``
+block::
+
+    >>> from statsd import statsd
+    >>> with statsd.timer('bar') as timer:
+    ...     func()
+    >>> print timer.ms  # Elapsed time in milliseconds.
+
 
 Decorator
 =========

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -5,6 +5,12 @@ import threading
 import time
 
 
+class TimerResult(object):
+
+    def __init__(self, ms=None):
+        self.ms = ms
+
+
 class _Timer(object):
     """A contextdecorator for timing."""
     _local = threading.local()
@@ -37,12 +43,15 @@ class _Timer(object):
 
     def __enter__(self):
         self.start = time.time()
+        self.result = TimerResult()
+        return self.result
 
     def __exit__(self, typ, value, tb):
         dt = time.time() - self.start
         dt = int(round(dt * 1000))  # Convert to ms.
+        self.result.ms = dt
         self.client.timing(self.stat, dt, self.rate)
-        del self.start, self.stat, self.rate  # Clean up.
+        del self.start, self.stat, self.rate, self.result  # Clean up.
         return False
 
 

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -93,6 +93,14 @@ def test_timer():
     _timer_check(sc, 2, 'bar', 'ms')
 
 
+def test_timer_capture():
+    """You can capture the output of StatsClient.timer."""
+    sc = _client()
+    with sc.timer('woo') as result:
+        eq_(result.ms, None)
+    assert isinstance(result.ms, int)
+
+
 @mock.patch.object(random, 'random', lambda: -1)
 def test_timer_rate():
     sc = _client()


### PR DESCRIPTION
Sometimes I want to do something with the `timer()` results. The whole `with` construct is very convenient, so I'd rather not do it all myself and then call `statsd.timing()`.

Returning an object is kind of awkward but I think it's necessary since the value is captured in `__enter__`, not `__exit__`.

I was going to push this to my branch but `git push origin ...` feels too good on my fingers.
