### PR TITLE
use gethostbyname instead of gethostbyaddr

### DIFF
--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -17,7 +17,7 @@ __version__ = '.'.join(map(str, VERSION))
 if settings:
     try:
         host = getattr(settings, 'STATSD_HOST', 'localhost')
-        host = socket.gethostbyaddr(host)[2][0]
+        host = socket.gethostbyname(host)
         port = getattr(settings, 'STATSD_PORT', 8125)
         prefix = getattr(settings, 'STATSD_PREFIX', None)
         statsd = StatsClient(host, port, prefix)


### PR DESCRIPTION
gethostbyaddr does a forward lookup to find the canonical IP addr for a DNS name, then does a reverse lookup on the IP addr to find the canonical hostname. It fails if there is no reverse DNS entry.

gethostbyname does a simple forward lookup only and handles names or IP addrs just fine.
