### PR TITLE
Python 3.2 and 2.5 support; tox test running.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.egg-info
 build
 dist
+.tox
+.coverage

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,8 @@
 from setuptools import setup, find_packages
 
-import statsd
-
 setup(
     name='statsd',
-    version=statsd.__version__,
+    version='0.5.1',
     description='A simple statsd client.',
     long_description=open('README.rst').read(),
     author='James Socol',
@@ -21,6 +19,12 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.2',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]
 )

--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import socket
 
@@ -6,7 +7,7 @@ try:
 except ImportError:
     settings = None
 
-from client import StatsClient
+from .client import StatsClient
 
 
 __all__ = ['StatsClient', 'statsd']

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 from functools import wraps
 import random
 import socket
@@ -70,7 +71,8 @@ class StatsClient(object):
             stat = '%s.%s' % (self._prefix, stat)
 
         try:
-            self._sock.sendto('%s:%s' % (stat, value), self._addr)
+            txt = '%s:%s' % (stat, value)
+            self._sock.sendto(txt.encode('ascii'), self._addr)
         except socket.error:
             # No time for love, Dr. Jones!
             pass

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -1,3 +1,4 @@
+from __future__ import with_statement
 import random
 import re
 import socket
@@ -18,6 +19,7 @@ def _client(prefix=None):
 
 
 def _sock_check(cl, count, val):
+    val = val.encode('ascii')
     eq_(cl._sock.sendto.call_count, count)
     eq_(cl._sock.sendto.call_args, ((val, ADDR), {}))
 
@@ -92,7 +94,7 @@ def test_prefix():
 
 def _timer_check(cl, count, start, end):
     eq_(cl._sock.sendto.call_count, count)
-    value = cl._sock.sendto.call_args[0][0]
+    value = cl._sock.sendto.call_args[0][0].decode('ascii')
     exp = re.compile('^%s:\d+|%s$' % (start, end))
     assert exp.match(value)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py25,py26,py27,pypy,py32
+
+[testenv]
+deps=
+    mock==0.8
+    nose
+    coverage
+
+commands=
+    nosetests statsd --with-coverage --cover-package=statsd []


### PR DESCRIPTION
socket.send expects bytes in Python 3 (while python 2 doesn't care) and it looks like statsd server implementations doesn't support non-ascii data so the data is forced to ascii.
I don't care much about python 2.5 but its support was only single **future** import away so it was added.
Travis CI is great but tox is better for TDD because tests can be run locally without commiting so tox.ini was added.
Version management was simplified (more KISS, less DRY) because importing packages in setup.py causes headaches.
