### PR TITLE
Thread safety and debugging options

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -27,10 +27,13 @@ their defaults, are::
     statsd = StatsClient(host='localhost',
                          port=8125,
                          prefix=None,
-                         batch_len=1)
+                         batch_len=1,
+                         thread_safe=False,
+                         debug=False)
 
 ``host`` is the host running the statsd server. It will support any kind of
-name or IP address you might use.
+name or IP address you might use. You can also pass ``None`` to disable
+reporting (dry-run mode)
 
 ``port`` is the statsd server port. The default for both server and client is
 ``8125``.
@@ -57,6 +60,12 @@ stat." If it is set to ``n``, the client will only send data to the server
 after every ``n`` other stats calls. It can be flushed to the server by calling
 ``StatsClient.flush()`` (see :ref:`flush`).
 
+Setting ``thread_safe`` will make sure that a single ``StatsClient`` can be
+safely used by multiple threads. This is achieved by locking access to internal
+structures.
+
+Setting ``debug`` to ``True`` will enable logging of every event to stdout.
+
 
 In Django
 =========
@@ -70,6 +79,8 @@ Here are the settings and their defaults::
     STATSD_PORT = 8125
     STATSD_PREFIX = None
     STATSD_BATCH_LEN = 1
+    STATSD_THREAD_SAFE = False
+    STATSD_DEBUG = False
 
 You can use the default ``StatsClient`` simply::
 
@@ -94,6 +105,8 @@ You can set these variables in the environment::
     STATSD_PORT
     STATSD_PREFIX
     STATSD_BATCH_LEN
+    STATSD_THREAD_SAFE
+    STATSD_DEBUG
 
 and then in your Python application, you can simply do::
 

--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -24,7 +24,9 @@ if settings:
         port = getattr(settings, 'STATSD_PORT', 8125)
         prefix = getattr(settings, 'STATSD_PREFIX', None)
         batch_len = getattr(settings, 'STATSD_BATCH_LEN', 1)
-        statsd = StatsClient(host, port, prefix, batch_len)
+        thread_safe = getattr(settings, 'STATSD_THREAD_SAFE', False)
+        debug = getattr(settings, 'STATSD_DEBUG', False)
+        statsd = StatsClient(host, port, prefix, batch_len, thread_safe, debug)
     except (socket.error, socket.gaierror, ImportError):
         pass
 elif 'STATSD_HOST' in os.environ:
@@ -33,6 +35,8 @@ elif 'STATSD_HOST' in os.environ:
         port = int(os.environ['STATSD_PORT'])
         prefix = os.environ.get('STATSD_PREFIX')
         batch_len = int(os.environ.get('STATSD_BATCH_LEN', 1))
-        statsd = StatsClient(host, port, prefix, batch_len)
+        thread_safe = os.environ.get('STATSD_THREAD_SAFE') == 'True'
+        debug = os.environ.get('STATSD_DEBUG') == 'True'
+        statsd = StatsClient(host, port, prefix, batch_len, thread_safe, debug)
     except (socket.error, socket.gaierror, KeyError):
         pass


### PR DESCRIPTION
- thread_safe constructor argument enables _stats
  single-threaded access to support use of single instance by
  multiple threads
- debug constructor argument enables stdout printing of every
  metric sent to statsd
- host may be None in which case network access is turned off
