### PR TITLE
Adds a meter method to the client.

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -61,6 +61,10 @@ class StatsClient(object):
         """Set a gauge value."""
         self._send(stat, '%s|g' % value, rate)
 
+    def meter(self, stat, count=1, rate=1):
+        """Increment a meter value."""
+        self._send(stat, '%s|m' % count, rate)
+
     def flush(self):
         """Flush the stats batching buffer."""
         if (0 < len(self._stats)):


### PR DESCRIPTION
This change adds the `meter(stat, count=1, rate=1)` method to `StatsClient`, a metric type supported by several statsd flavors.

Reference documentation was found here: https://github.com/b/statsd_spec#meters
