### PR TITLE
Add suffix parameter

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -26,7 +26,8 @@ They, and their defaults, are::
 
     statsd = StatsClient(host='localhost',
                          port=8125,
-                         prefix=None)
+                         prefix=None,
+                         suffix=None)
 
 ``host`` is the host running the statsd server. It will support any kind
 of name or IP address you might use.
@@ -50,6 +51,19 @@ will produce two different stats, ``foo.baz`` and ``bar.baz``. Without
 the ``prefix`` argument, or with the same ``prefix``, two
 ``StatsClient`` instances will update the same stats.
 
+``suffix`` can also be used to distinguish between hosts or environments.
+The suffix will be appended to all stats, automatically. This is useful
+when working with clusters consisting of multiple hosts. For example::
+
+    from statsd import StatsClient
+    from os import uname
+
+    myhostname = uname()[1].split(".")[0]
+    stats = StatsClient(suffix=myhostname)
+
+will append ``.hostname`` to all stats sent to statsd. Without this, all
+hosts in a cluster would update the same stats.
+
 
 In Django
 =========
@@ -63,6 +77,7 @@ Here are the settings and their defaults::
     STATSD_HOST = 'localhost'
     STATSD_PORT = 8125
     STATSD_PREFIX = None
+    STATSD_SUFFIX = None
 
 You can use the default ``StatsClient`` simply::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,11 +20,11 @@ Quickly, to use::
     >>> c.incr('foo')  # Increment the 'foo' counter.
     >>> c.timing('stats.timed', 320)  # Record a 320ms 'stats.timed'.
 
-You can also add a prefix to all your stats::
+You can also add a prefix and/or suffix to all your stats::
 
     >>> import statsd
-    >>> c = statsd.StatsClient('localhost', 8125, prefix='foo')
-    >>> c.incr('bar')  # Will be 'foo.bar' in statsd/graphite.
+    >>> c = statsd.StatsClient('localhost', 8125, prefix='foo', suffix='baz')
+    >>> c.incr('bar')  # Will be 'foo.bar.baz' in statsd/graphite.
 
 
 Installing

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -21,7 +21,7 @@ statsd_ server supports.
 
 ::
 
-    StatsClient(host='localhost', port=8125, prefix=None)
+    StatsClient(host='localhost', port=8125, prefix=None, suffix=None)
 
 Create a new ``StatsClient`` instance with the appropriate connection
 and prefix information.
@@ -33,6 +33,8 @@ and prefix information.
 * ``prefix``: a prefix to distinguish and group stats from an
   application or environment.
 
+* ``suffix``: a suffix to distinguish and group stats from an
+  application or environment.
 
 .. _incr:
 

--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -20,7 +20,8 @@ if settings:
         host = getattr(settings, 'STATSD_HOST', 'localhost')
         port = getattr(settings, 'STATSD_PORT', 8125)
         prefix = getattr(settings, 'STATSD_PREFIX', None)
-        statsd = StatsClient(host, port, prefix)
+        suffix = getattr(settings, 'STATSD_SUFFIX', None)
+        statsd = StatsClient(host, port, prefix, suffix)
     except (socket.error, socket.gaierror, ImportError):
         pass
 elif 'STATSD_HOST' in os.environ:
@@ -28,6 +29,7 @@ elif 'STATSD_HOST' in os.environ:
         host = os.environ['STATSD_HOST']
         port = int(os.environ['STATSD_PORT'])
         prefix = os.environ.get('STATSD_PREFIX')
-        statsd = StatsClient(host, port, prefix)
+        suffix = os.environ.get('STATSD_SUFFIX')
+        statsd = StatsClient(host, port, prefix, suffix)
     except (socket.error, socket.gaierror, KeyError):
         pass

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -37,11 +37,12 @@ class Timer(object):
 class StatsClient(object):
     """A client for statsd."""
 
-    def __init__(self, host='localhost', port=8125, prefix=None):
+    def __init__(self, host='localhost', port=8125, prefix=None, suffix=None):
         """Create a new client."""
         self._addr = (socket.gethostbyname(host), port)
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._prefix = prefix
+        self._suffix = suffix
 
     def _after(self, data):
         self._send(data)
@@ -88,6 +89,9 @@ class StatsClient(object):
         if self._prefix:
             stat = '%s.%s' % (self._prefix, stat)
 
+        if self._suffix:
+            stat = '%s.%s' % (stat, self._suffix)
+
         data = '%s:%s' % (stat, value)
         return data
 
@@ -104,6 +108,7 @@ class Pipeline(StatsClient):
     def __init__(self, client):
         self._client = client
         self._prefix = client._prefix
+        self._suffix = client._suffix
         self._stats = []
 
     def _after(self, data):

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -12,8 +12,8 @@ from statsd import StatsClient
 ADDR = (socket.gethostbyname('localhost'), 8125)
 
 
-def _client(prefix=None):
-    sc = StatsClient(host=ADDR[0], port=ADDR[1], prefix=prefix)
+def _client(prefix=None, suffix=None):
+    sc = StatsClient(host=ADDR[0], port=ADDR[1], prefix=prefix, suffix=suffix)
     sc._sock = mock.Mock()
     return sc
 
@@ -182,6 +182,20 @@ def test_prefix():
 
     sc.incr('bar')
     _sock_check(sc, 1, 'foo.bar:1|c')
+
+
+def test_suffix():
+    sc = _client(suffix='foo')
+
+    sc.incr('bar')
+    _sock_check(sc, 1, 'bar.foo:1|c')
+
+
+def test_prefix_and_suffix():
+    sc = _client(prefix='fooprefix', suffix='foosuffix')
+
+    sc.incr('bar')
+    _sock_check(sc, 1, 'fooprefix.bar.foosuffix:1|c')
 
 
 def _timer_check(cl, count, start, end):


### PR DESCRIPTION
We've been maintaining our own statsd client module for a while, but I want to start using this one. It covers all our requirements, except it can't add a suffix to a metric key. This PR introduces that functionality.

The use case for this is clusters with many machines. Our applications send metrics that look like this:
[env].[team].[app_name].[metric].[submetric].[host]

The prefix for the application is set to '[env].[team].[app_name]' and the suffix is set to '[host]'

Changes included:
- Added a statsd suffix that works just like the prefix, but appends to the metric's key instead
- Added tests
- Updated documentation
