### PR TITLE
Adding support for statsd sets

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -78,6 +78,13 @@ class StatsClient(object):
         if data is not None:
             self._after(data)
 
+    def set(self, stat, value):
+        """Send a value to your set."""
+        value = '%g|s' % value
+        data = self._prepare(stat, value)
+        if data is not None:
+            self._after(data)
+
     def _prepare(self, stat, value, rate=1):
         if rate < 1:
             if random.random() < rate:

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -131,6 +131,16 @@ def test_gauge():
     _sock_check(sc, 3, 'foo:70|g|@0.5')
 
 
+@mock.patch.object(random, 'random', lambda: -1)
+def test_set():
+    sc = _client()
+    sc.set('foo', 30)
+    _sock_check(sc, 1, 'foo:30|s')
+
+    sc.set('foo', 1.2)
+    _sock_check(sc, 2, 'foo:1.2|s')
+
+
 def test_gauge_delta():
     sc = _client()
     sc.gauge('foo', 12, delta=True)


### PR DESCRIPTION
About 9 months ago, https://github.com/etsy/statsd/pull/152 was merged into statsd. I thought I would add support for this in your python statsd api. Been using it in production for a couple weeks now and seems to work.
