### PR TITLE
don't `pop` or try to send on an empty pipeline

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -117,6 +117,8 @@ class Pipeline(StatsClient):
 
     def send(self):
         # Use pop(0) to preserve the order of the stats.
+        if not self._stats:
+            return
         data = self._stats.pop(0)
         while self._stats:
             stat = self._stats.pop(0)

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -280,6 +280,13 @@ def test_pipeline():
     _sock_check(sc, 1, 'foo:1|c\nbar:-1|c\nbaz:320|ms')
 
 
+def test_pipeline_null():
+    """ensure we don't error on a null pipeline"""
+    sc = _client()
+    pipe = sc.pipeline()
+    pipe.send()
+
+
 def test_pipeline_manager():
     sc = _client()
     with sc.pipeline() as pipe:


### PR DESCRIPTION
the current code will try to pop on an empty pipeline. i updated this to exit early on an empty list.

why?

if you're using a pipeline to wrap a web request ( via middleware or app logic ), you don't necessarily know if the pipeline has been filled or not.  inspecting pipe._stats works, but  that's messy.  this lets you just call send() and not worry.
