### PR TITLE
Prevent rounding big numbers in gauges

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -71,9 +71,9 @@ class StatsClient(object):
     def gauge(self, stat, value, rate=1, delta=False):
         """Set a gauge value."""
         if delta:
-            value = '%+g|g' % value
+            value = '%+f|g' % value
         else:
-            value = '%g|g' % value
+            value = '%f|g' % value
         data = self._prepare(stat, value, rate)
         if data is not None:
             self._after(data)


### PR DESCRIPTION
The format string %g rounds big numbers. For example, the gauge 1234567890 will appear as 1234570000 in statsd. %f will keep the precision.
