### PR TITLE
Fix for wrapper function returning 0ms timings

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -43,7 +43,7 @@ class Timer(object):
             raise RuntimeError('Timer has not started.')
         dt = time.time() - self._start_time
         self.ms = int(round(1000 * dt))  # Convert to milliseconds.
-        if send:
+        if send and self.ms > 0:
             self.send()
         return self
 


### PR DESCRIPTION
DEBUG: Bad line: 0,ms in msg "production.timer:0|ms"
https://github.com/etsy/statsd/blob/5b900711191a9c5cfd536c877a3c119d1df5679a/lib/helpers.js#L35
return isNumber(fields[0]) && Number(fields[0]) > 0;

statsD expects a > 0 number for ms counters.
