### PR TITLE
Link to graphite.readthedocs.org instead of wikidot

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -67,4 +67,4 @@ Indices and tables
 * :ref:`search`
 
 .. _statsd: https://github.com/etsy/statsd
-.. _Graphite: http://graphite.wikidot.com/
+.. _Graphite: http://graphite.readthedocs.org/


### PR DESCRIPTION
The link to wikidot is outdated and refers back to graphite.readthedocs.org, so use that in the first place.
