### PR TITLE
Two more doc references fixed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,5 +50,5 @@ There are lots of docs in the ``docs/`` directory and on ReadTheDocs_.
 
 
 .. _statsd: https://github.com/etsy/statsd
-.. _Graphite: http://graphite.wikidot.com/
+.. _Graphite: http://graphite.readthedocs.org/
 .. _ReadTheDocs: http://statsd.readthedocs.org/en/latest/index.html

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -160,5 +160,5 @@ same sample period, that userid will only be counted once.
 
 
 .. _statsd: https://github.com/etsy/statsd
-.. _Graphite: http://graphite.wikidot.com/
+.. _Graphite: http://graphite.readthedocs.org
 .. _3eecd18: https://github.com/etsy/statsd/commit/3eecd18


### PR DESCRIPTION
Two more Graphite references moved from wikidot to readthedocs.
Missed the obvious one, search pointed out one other.
