### PR TITLE
Updated Timer's __call__ method to be thread-safe for decorators

### DIFF
--- a/docs/timing.rst
+++ b/docs/timing.rst
@@ -52,9 +52,9 @@ block::
 Using a decorator
 =================
 
-The ``timer`` attribute can also be used as a function decorator. Every
-time the decorated function is called, the time it took to execute will
-be sent to the statsd server.
+The ``timer`` attribute decorates your methods in a thread-safe manner.
+Every time the decorated function is called, the time it took to execute
+will be sent to the statsd server.
 
 ::
 
@@ -70,10 +70,6 @@ be sent to the statsd server.
     myfunc(1, 2)
     myfunc(3, 7)
 
-.. warning::
-   Decorators are not thread-safe and may cause errors when decorated
-   functions are called concurrently. Use context managers or raw timers
-   instead.
 
 
 Using a Timer object directly

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -20,11 +20,16 @@ class Timer(object):
         self._start_time = None
 
     def __call__(self, f):
-        @wraps(f)
-        def wrapper(*args, **kw):
-            with self:
-                return f(*args, **kw)
-        return wrapper
+        """Thread-safe timing function decorator."""
+        def decorated_function(*args, **kwargs):
+            start_time = time.time()
+            try:
+                return_value = f(*args, **kwargs)
+            finally:
+                elapsed_time_ms = int(round(1000 * (time.time() - start_time)))
+                self.client.timing(self.stat, elapsed_time_ms, self.rate)
+            return return_value
+        return decorated_function
 
     def __enter__(self):
         return self.start()


### PR DESCRIPTION
I left the existing thread-unsafe __ call __ stuff alone for backwards-compatibility.
