### PR TITLE
Refactoring StatsClient & Pipeline using base classes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ Contents
    types.rst
    timing.rst
    pipeline.rst
+   tcp.rst
    reference.rst
    contributing.rst
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -275,6 +275,93 @@ stats.
    This method is not implemented on the base StatsClient class.
 
 
+.. _TCPStatsClient:
+
+``TCPStatsClient``
+==================
+
+::
+
+    TCPStatsClient(host='localhost', port=8125, prefix=None, timeout=None)
+
+Create a new ``TCPStatsClient`` instance with the appropriate connection
+and prefix information.
+
+* ``host``: the hostname or IPv4 address of the statsd_ server.
+
+* ``port``: the port of the statsd server.
+
+* ``prefix``: a prefix to distinguish and group stats from an
+  application or environment.
+
+* ``timeout``: socket timeout for any actions on the connection socket.
+
+
+``TCPStatsClient`` implements all methods of ``StatsClient``, with the
+difference that it is not thread safe and it can raise exceptions on
+connection errors.  On the contrary to ``StatsClient`` it uses a ``TCP``
+connection to connect to Statsd.
+Additionally to the methods of ``StatsClient`` it has a few which are
+specific to ``TCP`` connections.
+
+
+.. _tcp_close:
+
+``close``
+---------
+
+::
+
+    from statsd import TCPStatsClient
+
+    statsd = TCPStatsClient()
+    statsd.incr('some.event')
+    statsd.close()
+
+Closes a connection that's currently open and deletes it's socket. If this is
+called on a ``TCPStatsClient`` which currently has no open connection it is a
+non-action.
+
+
+.. _tcp_connect:
+
+``connect``
+-----------
+
+::
+
+    from statsd import TCPStatsClient
+
+    statsd = TCPStatsClient()
+    statsd.incr('some.event')  # calls connect() internally
+    statsd.close()
+    statsd.connect()  # creates new connection
+
+Creates a connection to Statsd. If there are errors like connection timed out
+or connection refused, the according exceptions will be raised. It is usually
+not necessary to call this method because sending data to Statsd will call
+``connect`` implicitely if the current instance of ``TCPStatsClient`` does not
+already hold an open connection.
+
+
+.. _tcp_reconnect:
+
+``reconnect``
+-------------
+
+::
+
+    from statsd import TCPStatsClient
+
+    statsd = TCPStatsClient()
+    statsd.incr('some.event')
+    statsd.reconnect()  # closes open connection and creates new one
+
+Closes a currently existing connection and replaces it with a new one. If no
+connection exists already it will simply create a new one.  Internally this
+does nothing else than calling ``close()`` and ``connect()``.
+
+
 .. _statsd: https://github.com/etsy/statsd
 .. _0ed78be: https://github.com/etsy/statsd/commit/0ed78be7
 .. _1c10cfc0ac: https://github.com/etsy/statsd/commit/1c10cfc0ac

--- a/docs/tcp.rst
+++ b/docs/tcp.rst
@@ -1,0 +1,19 @@
+.. _tcp-chapter:
+
+==============
+TCPStatsClient
+==============
+
+The ``TCPStatsClient`` class has a very similar interface to ``StatsClient``,
+but internally it uses ``TCP`` connections instead of ``UDP``. These are the
+main differencies when using ``TCPStatsClient`` compared to ``StatsClient``:
+
+* The constructor supports a ``timeout`` parameter to set a timeout on all
+  socket actions.
+
+* The methods ``connect`` and all methods that send data can potentially raise
+  socket exceptions.
+
+* It is not thread-safe, so it is recommended to not share it across threads
+  unless a lot of attention is paid to make sure that no two threads ever use
+  it at once.

--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
 
 from .client import StatsClient
+from .client import TCPStatsClient
 
 
 VERSION = (3, 0, 1)
 __version__ = '.'.join(map(str, VERSION))
-__all__ = ['StatsClient']
+__all__ = ['StatsClient', 'TCPStatsClient']

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -4,6 +4,7 @@ from functools import wraps
 import random
 import socket
 import time
+import abc
 
 
 __all__ = ['StatsClient']
@@ -63,22 +64,18 @@ class Timer(object):
         self.client.timing(self.stat, self.ms, self.rate)
 
 
-class StatsClient(object):
-    """A client for statsd."""
+class StatsClientBase(object):
+    """A Base class for various statsd clients."""
 
-    def __init__(self, host='localhost', port=8125, prefix=None,
-                 maxudpsize=512):
-        """Create a new client."""
-        family, _, _, _, addr = socket.getaddrinfo(
-            host, port, 0, socket.SOCK_DGRAM
-        )[0]
-        self._addr = addr
-        self._sock = socket.socket(family, socket.SOCK_DGRAM)
-        self._prefix = prefix
-        self._maxudpsize = maxudpsize
+    __metaclass__ = abc.ABCMeta
 
+    @abc.abstractmethod
+    def _send(self):
+        pass
+
+    @abc.abstractmethod
     def pipeline(self):
-        return Pipeline(self)
+        pass
 
     def timer(self, stat, rate=1):
         return Timer(self, stat, rate)
@@ -130,6 +127,21 @@ class StatsClient(object):
         if data:
             self._send(data)
 
+
+class StatsClient(StatsClientBase):
+    """A client for statsd."""
+
+    def __init__(self, host='localhost', port=8125, prefix=None,
+                 maxudpsize=512):
+        """Create a new client."""
+        family, _, _, _, addr = socket.getaddrinfo(
+            host, port, 0, socket.SOCK_DGRAM
+        )[0]
+        self._addr = addr
+        self._sock = socket.socket(family, socket.SOCK_DGRAM)
+        self._prefix = prefix
+        self._maxudpsize = maxudpsize
+
     def _send(self, data):
         """Send data to statsd."""
         try:
@@ -138,13 +150,22 @@ class StatsClient(object):
             # No time for love, Dr. Jones!
             pass
 
+    def pipeline(self):
+        return Pipeline(self)
 
-class Pipeline(StatsClient):
+
+class PipelineBase(StatsClientBase):
+
+    __metaclass__ = abc.ABCMeta
+
     def __init__(self, client):
         self._client = client
         self._prefix = client._prefix
-        self._maxudpsize = client._maxudpsize
         self._stats = deque()
+
+    @abc.abstractmethod
+    def _send(self):
+        pass
 
     def _after(self, data):
         if data is not None:
@@ -157,11 +178,24 @@ class Pipeline(StatsClient):
         self.send()
 
     def send(self):
-        # Use popleft to preserve the order of the stats.
         if not self._stats:
             return
+        self._send()
+
+    def pipeline(self):
+        return self.__class__(self)
+
+
+class Pipeline(PipelineBase):
+
+    def __init__(self, client):
+        super(Pipeline, self).__init__(client)
+        self._maxudpsize = client._maxudpsize
+
+    def _send(self):
         data = self._stats.popleft()
         while self._stats:
+            # Use popleft to preserve the order of the stats.
             stat = self._stats.popleft()
             if len(stat) + len(data) + 1 >= self._maxudpsize:
                 self._client._after(data)

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -7,7 +7,7 @@ import time
 import abc
 
 
-__all__ = ['StatsClient']
+__all__ = ['StatsClient', 'TCPStatsClient']
 
 
 class Timer(object):
@@ -154,6 +154,46 @@ class StatsClient(StatsClientBase):
         return Pipeline(self)
 
 
+class TCPStatsClient(StatsClientBase):
+    """TCP version of StatsClient."""
+
+    def __init__(self, host='localhost', port=8125, prefix=None, timeout=None):
+        """Create a new client."""
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+        self._prefix = prefix
+        self._sock = None
+
+    def _send(self, data):
+        """Send data to statsd."""
+        if not self._sock:
+            self.connect()
+        self._do_send(data)
+
+    def _do_send(self, data):
+        self._sock.sendall(data.encode('ascii') + b'\n')
+
+    def close(self):
+        if self._sock and hasattr(self._sock, 'close'):
+            self._sock.close()
+        self._sock = None
+
+    def connect(self):
+        family, _, _, _, addr = socket.getaddrinfo(
+            self._host, self._port, 0, socket.SOCK_STREAM)[0]
+        self._sock = socket.socket(family, socket.SOCK_STREAM)
+        self._sock.settimeout(self._timeout)
+        self._sock.connect(addr)
+
+    def pipeline(self):
+        return TCPPipeline(self)
+
+    def reconnect(self, data):
+        self.close()
+        self.connect()
+
+
 class PipelineBase(StatsClientBase):
 
     __metaclass__ = abc.ABCMeta
@@ -203,3 +243,10 @@ class Pipeline(PipelineBase):
             else:
                 data += '\n' + stat
         self._client._after(data)
+
+
+class TCPPipeline(PipelineBase):
+
+    def _send(self):
+        self._client._after('\n'.join(self._stats))
+        self._stats.clear()


### PR DESCRIPTION
This refers to pull request #57, it is another (better) implementation with the same goal, to implement TCP connections.

The interface of the StatsClient and Pipeline are still the same, but part of their code has been moved into a base class. This same base class is inherited by TCPStatsClient and TCPPipeline which implement the same functionality, but use TCP instead of UDP. 

The TCP versions can raise exceptions, I did not implement a way to make them swallow the exceptions because if somebody is not interested in whether the data has arrived at Statsd he might as well use UDP.