### PR TITLE
Ignore RuntimeErrors together with socket errors

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -146,7 +146,7 @@ class StatsClient(StatsClientBase):
         """Send data to statsd."""
         try:
             self._sock.sendto(data.encode('ascii'), self._addr)
-        except socket.error:
+        except (socket.error, RuntimeError):
             # No time for love, Dr. Jones!
             pass
 


### PR DESCRIPTION
When Python's standard library is patched with Eventlet the exception
raised when two threads access the same socket simultaneously is
RuntimeError and I think it makes sense to include it here.

The downside is it may start ignoring too wide variety of exceptions but
on the other hand I can't think of any other RuntimeErrors that can be
raised here.