### PR TITLE
Updated statsd client to allow less than 1 ms timing

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Version 3.2
 -----------
 
 - Add an explicit IPv6 flag.
+- Add support for sub-millisecond timings
 
 
 Version 3.1

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -29,7 +29,7 @@ class Timer(object):
             try:
                 return_value = f(*args, **kwargs)
             finally:
-                elapsed_time_ms = int(round(1000 * (time.time() - start_time)))
+                elapsed_time_ms = 1000.0 * (time.time() - start_time)
                 self.client.timing(self.stat, elapsed_time_ms, self.rate)
             return return_value
         return _wrapped
@@ -50,7 +50,7 @@ class Timer(object):
         if self._start_time is None:
             raise RuntimeError('Timer has not started.')
         dt = time.time() - self._start_time
-        self.ms = int(round(1000 * dt))  # Convert to milliseconds.
+        self.ms = 1000.0 * dt  # Convert to milliseconds.
         if send:
             self.send()
         return self
@@ -82,7 +82,7 @@ class StatsClientBase(object):
 
     def timing(self, stat, delta, rate=1):
         """Send new timing information. `delta` is in milliseconds."""
-        self._send_stat(stat, '%d|ms' % delta, rate)
+        self._send_stat(stat, '%f|ms' % delta, rate)
 
     def incr(self, stat, count=1, rate=1):
         """Increment a stat by `count`."""

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -355,13 +355,13 @@ def test_set_tcp():
 
 def _test_timing(cl, proto):
     cl.timing('foo', 100)
-    _sock_check(cl._sock, 1, proto, 'foo:100|ms')
+    _sock_check(cl._sock, 1, proto, 'foo:100.000000|ms')
 
     cl.timing('foo', 350)
-    _sock_check(cl._sock, 2, proto, 'foo:350|ms')
+    _sock_check(cl._sock, 2, proto, 'foo:350.000000|ms')
 
     cl.timing('foo', 100, rate=0.5)
-    _sock_check(cl._sock, 3, proto, 'foo:100|ms|@0.5')
+    _sock_check(cl._sock, 3, proto, 'foo:100.000000|ms|@0.5')
 
 
 @mock.patch.object(random, 'random', lambda: -1)
@@ -481,7 +481,7 @@ def test_timer_decorator_tcp():
 def _test_timer_capture(cl, proto):
     with cl.timer('woo') as result:
         eq_(result.ms, None)
-    assert isinstance(result.ms, int)
+    assert isinstance(result.ms, float)
 
 
 def test_timer_capture_udp():
@@ -715,7 +715,7 @@ def _test_pipeline(cl, proto):
     pipe.decr('bar')
     pipe.timing('baz', 320)
     pipe.send()
-    _sock_check(cl._sock, 1, proto, 'foo:1|c\nbar:-1|c\nbaz:320|ms')
+    _sock_check(cl._sock, 1, proto, 'foo:1|c\nbar:-1|c\nbaz:320.000000|ms')
 
 
 def test_pipeline_udp():
@@ -868,21 +868,20 @@ def test_pipeline_negative_absolute_gauge_tcp():
 
 def _test_big_numbers(cl, proto):
     num = 1234568901234
-    result = 'foo:1234568901234|%s'
     tests = (
         # Explicitly create strings so we avoid the bug we're trying to test.
-        ('gauge', 'g'),
-        ('incr', 'c'),
-        ('timing', 'ms'),
+        ('gauge', 'foo:1234568901234|g'),
+        ('incr', 'foo:1234568901234|c'),
+        ('timing', 'foo:1234568901234.000000|ms'),
     )
 
-    def _check(method, suffix):
+    def _check(method, result):
         cl._sock.reset_mock()
         getattr(cl, method)('foo', num)
-        _sock_check(cl._sock, 1, proto, result % suffix)
+        _sock_check(cl._sock, 1, proto, result)
 
-    for method, suffix in tests:
-        _check(method, suffix)
+    for method, result in tests:
+        _check(method, result)
 
 
 def test_big_numbers_udp():


### PR DESCRIPTION
This is a version of https://github.com/jsocol/pystatsd/pull/63 changed to include code review feedback.