### PR TITLE
Don't break compatibility with code that uses ordered args

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -131,8 +131,8 @@ class StatsClientBase(object):
 class StatsClient(StatsClientBase):
     """A client for statsd."""
 
-    def __init__(self, host='localhost', port=8125, ipv6=False, prefix=None,
-                 maxudpsize=512):
+    def __init__(self, host='localhost', port=8125, prefix=None,
+                 maxudpsize=512, ipv6=False):
         """Create a new client."""
         fam = socket.AF_INET6 if ipv6 else socket.AF_INET
         family, _, _, _, addr = socket.getaddrinfo(
@@ -157,8 +157,8 @@ class StatsClient(StatsClientBase):
 class TCPStatsClient(StatsClientBase):
     """TCP version of StatsClient."""
 
-    def __init__(self, host='localhost', port=8125, ipv6=False, prefix=None,
-                 timeout=None):
+    def __init__(self, host='localhost', port=8125, prefix=None,
+                 timeout=None, ipv6=False):
         """Create a new client."""
         self._host = host
         self._port = port


### PR DESCRIPTION
We have some libraries that call StatsClient(host, port, prefix). Adding the ipv6 arg in the middle of the args list breaks them. I would like to see this moved to the end of the args list.