### PR TITLE
fix assert_called_once() calls

### DIFF
--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -942,7 +942,7 @@ def test_tcp_raises_exception_to_user(mock_socket):
     addr = ('127.0.0.1', 1234)
     cl = _tcp_client(addr=addr[0], port=addr[1])
     cl.incr('foo')
-    cl._sock.sendall.assert_called_once()
+    eq_(1, cl._sock.sendall.call_count)
     cl._sock.sendall.side_effect = socket.error
     with assert_raises(socket.error):
         cl.incr('foo')
@@ -954,5 +954,4 @@ def test_tcp_timeout(mock_socket):
     test_timeout = 321
     cl = TCPStatsClient(timeout=test_timeout)
     cl.incr('foo')
-    cl._sock.settimeout.assert_called_once()
-    cl._sock.settimeout.assert_called_with(test_timeout)
+    cl._sock.settimeout.assert_called_once_with(test_timeout)


### PR DESCRIPTION
The assert_called_once() method [does not exist](http://engineeringblog.yelp.com/2015/02/assert_called_once-threat-or-menace.html), and it's causing [a build failure in Ubuntu](https://launchpadlibrarian.net/227055017/buildlog_ubuntu-xenial-amd64.python-statsd_3.2.1-1_BUILDING.txt.gz), as the latest version of mock doesn't let you use assertion methods that don't exist.

I've replaced them with their appropriate alternatives and tested against the pinned versions of nose/mock in your requirements.txt as well as the latest versions.