### PR TITLE
Add helper to instantiate from environment

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -12,7 +12,9 @@ Runtime
 =======
 
 If you are running the statsd_ server locally and on the default port,
-it's extremely easy::
+it's extremely easy
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -20,7 +22,9 @@ it's extremely easy::
     statsd.incr('foo')
 
 There are three arguments to configure your ``StatsClient`` instance.
-They, and their defaults, are::
+They, and their defaults, are
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -38,7 +42,9 @@ client is ``8125``.
 
 ``prefix`` helps distinguish multiple applications or environments using
 the same statsd server. It will be prepended to all stats,
-automatically. For example::
+automatically. For example
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -89,7 +95,9 @@ Here are the settings and their defaults::
     STATSD_PREFIX = None
     STATSD_MAXUDPSIZE = 512
 
-You can use the default ``StatsClient`` simply::
+You can use the default ``StatsClient`` simply
+
+.. code-block:: python
 
     from statsd.defaults.django import statsd
 
@@ -120,6 +128,19 @@ and then in your Python application, you can simply do::
     As of version 3.0, this default instance is always available,
     configured with the default values, unless overridden by the
     environment.
+
+There is also a helper to instantiate a client object from the these
+environment variables environment with
+``statsd.defaults.from_env()``
+
+.. code-block:: python
+
+     import statsd.defaults
+
+     class MyClass():
+         def __init__(self):
+             self.statsd = statsd.defaults.from_env()
+
 
 .. _statsd: https://github.com/etsy/statsd
 .. _Django: https://www.djangoproject.com/

--- a/statsd/defaults/__init__.py
+++ b/statsd/defaults/__init__.py
@@ -1,5 +1,21 @@
+import os
+
+from statsd.client import StatsClient
+
 HOST = 'localhost'
 PORT = 8125
 IPV6 = False
 PREFIX = None
 MAXUDPSIZE = 512
+
+
+def from_env():
+    """Return a StatsClient populated from environment variables"""
+
+    host = os.getenv('STATSD_HOST', HOST)
+    port = int(os.getenv('STATSD_PORT', PORT))
+    prefix = os.getenv('STATSD_PREFIX', PREFIX)
+    maxudpsize = int(os.getenv('STATSD_MAXUDPSIZE', MAXUDPSIZE))
+    ipv6 = bool(int(os.getenv('STATSD_IPV6', IPV6)))
+    return StatsClient(host=host, port=port, prefix=prefix,
+                       maxudpsize=maxudpsize, ipv6=ipv6)


### PR DESCRIPTION
In statsd 2.0 era, you used to "import statsd" which would set the
global statsd object to either a client, or, if no environment
variables were detected, to "None".  In 3.0 this moved into
"statsd.defaults.env" (where the semantics changed to use default
values).

So we have a bunch of code that relies on getting the statsd client
populated from environment variables from this legacy.

However, setting a global statsd object at import time has some
problems; for example it interferes with unit-testing where we want to
be able to call individual classes with different statsd targets to
make sure we're capturing their stats output for correctness.

So we can move our objects to creating their own StatsClient objects,
but there's no interface for instantiating that with values from the
environment.  Thus we end up writing a wrapper which has been
duplicated a few times.

This proposes such a wrapper for statsd directly.  With it, one can do

```python
 def __init__():
   self.statsd = statsd.defaults.from_env()
```

in their object and "self.statsd" will follow the semantics of
"statsd.defaults.env" for creating a StatsClient object.