### PR TITLE
Remove conflicting timer decorator warning on API reference page.

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -187,12 +187,6 @@ call.  See also the :ref:`chapter on timing <timing-chapter>`.
   this percentage of the time. The statsd server does *not* take the
   sample rate into account for timers.
 
-.. warning::
-   Decorators are not thread-safe and may cause errors when decorated
-   functions are called concurrently. Use context managers or raw timers
-   instead.
-
-
 .. _timer-start:
 
 ``start``


### PR DESCRIPTION
Made you a PR for #74, if it helps!
Feel free to discard if it's too simple or wrong or you're already doing it etc

Cheers,
Amédée