### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ for the statsd daemon.
 :Code:          https://github.com/jsocol/pystatsd
 :License:       MIT; see LICENSE file
 :Issues:        https://github.com/jsocol/pystatsd/issues
-:Documentation: http://statsd.readthedocs.org/
+:Documentation: https://statsd.readthedocs.io/
 
 Quickly, to use:
 
@@ -75,5 +75,5 @@ There are lots of docs in the ``docs/`` directory and on ReadTheDocs_.
 
 
 .. _statsd: https://github.com/etsy/statsd
-.. _Graphite: http://graphite.readthedocs.org/
-.. _ReadTheDocs: http://statsd.readthedocs.org/en/latest/index.html
+.. _Graphite: https://graphite.readthedocs.io/
+.. _ReadTheDocs: https://statsd.readthedocs.io/en/latest/index.html

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -91,4 +91,4 @@ heading in an existing chapter.
 
 .. _issue: https://github.com/jsocol/pystatsd/issues
 .. _virtualenv: http://www.virtualenv.org/
-.. _ReadTheDocs: http://statsd.readthedocs.org/
+.. _ReadTheDocs: https://statsd.readthedocs.io/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ for the statsd daemon.
 :Code:          https://github.com/jsocol/pystatsd
 :License:       MIT; see LICENSE file
 :Issues:        https://github.com/jsocol/pystatsd/issues
-:Documentation: http://statsd.readthedocs.org/
+:Documentation: https://statsd.readthedocs.io/
 
 Quickly, to use::
 
@@ -81,4 +81,4 @@ Indices and tables
 * :ref:`search`
 
 .. _statsd: https://github.com/etsy/statsd
-.. _Graphite: http://graphite.readthedocs.org/
+.. _Graphite: https://graphite.readthedocs.io/

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -160,5 +160,5 @@ same sample period, that userid will only be counted once.
 
 
 .. _statsd: https://github.com/etsy/statsd
-.. _Graphite: http://graphite.readthedocs.org
+.. _Graphite: https://graphite.readthedocs.io
 .. _3eecd18: https://github.com/etsy/statsd/commit/3eecd18


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.