### PR TITLE
Fix travis flake8 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
  - "3.5"
  - "pypy"
 install:
- - pip install -q flake8
+ - pip install -q "flake8<3.0.0" # Flake8 3.x dropped support of Python 2.6 and 3.3
 script:
  - nosetests
  - flake8 statsd/


### PR DESCRIPTION
This change prevent travis from installing flake8-3.x which is incompatible
with python-2.6