### PR TITLE
Add support for passing timedeltas to StatsClientBase.timing

### DIFF
--- a/docs/timing.rst
+++ b/docs/timing.rst
@@ -18,15 +18,24 @@ The simplest way to use a timer is to record the time yourself and send
 it manually, using the :ref:`timing` method::
 
     import time
+    from datetime import datetime
     from statsd import StatsClient
 
     statsd = StatsClient()
 
+    # Pass milliseconds directly
+
     start = time.time()
     time.sleep(3)
-
     # You must convert to milliseconds:
     dt = int((time.time() - start) * 1000)
+    statsd.timing('slept', dt)
+
+    # Or pass a timedelta
+
+    start = datetime.utcnow()
+    time.sleep(3)
+    dt = datetime.utcnow() - start
     statsd.timing('slept', dt)
 
 

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 from collections import deque
+from datetime import timedelta
 import functools
 import random
 import socket
@@ -95,7 +96,17 @@ class StatsClientBase(object):
         return Timer(self, stat, rate)
 
     def timing(self, stat, delta, rate=1):
-        """Send new timing information. `delta` is in milliseconds."""
+        """
+        Send new timing information.
+
+        `delta` can be either a number of milliseconds or a timedelta.
+        """
+        if isinstance(delta, timedelta):
+            # Convert timedelta to number of milliseconds. The total_seconds()
+            # methods isn't use as it isn't available in Python 2.6.
+            delta = (delta.days * 24 * 3600000.) + \
+                    (delta.seconds * 1000.) + \
+                    (delta.microseconds / 1000.)
         self._send_stat(stat, '%0.6f|ms' % delta, rate)
 
     def incr(self, stat, count=1, rate=1):

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -3,6 +3,7 @@ import functools
 import random
 import re
 import socket
+from datetime import timedelta
 
 import mock
 from nose.tools import eq_
@@ -363,6 +364,12 @@ def _test_timing(cl, proto):
 
     cl.timing('foo', 100, rate=0.5)
     _sock_check(cl._sock, 3, proto, 'foo:100.000000|ms|@0.5')
+
+    cl.timing('foo', timedelta(seconds=1.5))
+    _sock_check(cl._sock, 4, proto, 'foo:1500.000000|ms')
+
+    cl.timing('foo', timedelta(days=1.5), rate=0.2)
+    _sock_check(cl._sock, 5, proto, 'foo:129600000.000000|ms|@0.2')
 
 
 @mock.patch.object(random, 'random', lambda: -1)


### PR DESCRIPTION
This pull request adds support for passing `timedelta`s to `StatsClientBase.timing`. 

In situations where you have `timedelta`s, code like this:

`statsd.timining('my_timing_stat', td.total_seconds() * 1000.)`

Would reduce to:

`statsd.timing('my_timing_stat', td)`

As `total_seconds` was introduced in Python 2.7 the transformation to milliseconds will be done using regular arithmetic based on the example from the [python docs](https://docs.python.org/2/library/datetime.html#datetime.timedelta.total_seconds).