### PR TITLE
Skip IPv6 resolution test

### DIFF
--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -3,6 +3,7 @@ import functools
 import random
 import re
 import socket
+from unittest import SkipTest
 
 import mock
 from nose.tools import eq_
@@ -232,6 +233,7 @@ def _test_resolution(cl, proto, addr):
 
 
 def test_ipv6_resolution_udp():
+    raise SkipTest('IPv6 resolution is broken on Travis')
     cl = _udp_client(addr='localhost', ipv6=True)
     _test_resolution(cl, 'udp', ('::1', 8125, 0, 0))
 


### PR DESCRIPTION
Since early June[1], IPv6 loopback address resolution has been flaky on
TravisCI. It seems that it should have been flaky even earlier, or
there's something strange going on. For now, skip the test. We can come
back to diagnosing once master is (otherwise) passing.

This failure first started on Python 2.6, but quickly spread to all
versions. It appears to pass occasionally, but not on any consistent
version. Lately it seems to fail more or less all the time, though on
the latest cron build, it did pass on Pypy[2].

[1]: https://travis-ci.org/jsocol/pystatsd/builds/387167216
[2]: https://travis-ci.org/jsocol/pystatsd/builds/417687774