### PR TITLE
Drop support for old Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,13 @@
 language: python
 sudo: false
 python:
- - "2.6"
  - "2.7"
- - "3.2"
- - "3.3"
  - "3.4"
  - "3.5"
  - "3.6"
  - "pypy"
 install:
- - pip install -q "flake8<3.0.0" # Flake8 3.x dropped support of Python 2.6 and 3.3
+ - pip install -q "flake8"
 script:
- - nosetests
+ - nosetests --with-coverage --cover-package=statsd
  - flake8 statsd/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py32,py33,py34,py35,py36
+envlist = py27,pypy,py34,py35,py36
 
 [testenv]
 deps=


### PR DESCRIPTION
Leave Python 2.6, 3.2, and 3.3 out. Let's focus on >=3.4 (and we'll
still support 2.7 because it's easy).