### PR TITLE
Remove dependency on ABCMeta.

### DIFF
--- a/statsd/client.py
+++ b/statsd/client.py
@@ -3,7 +3,6 @@ from collections import deque
 import functools
 import random
 import socket
-import abc
 
 # Use timer that's not susceptable to time of day adjustments.
 try:
@@ -81,15 +80,11 @@ class Timer(object):
 class StatsClientBase(object):
     """A Base class for various statsd clients."""
 
-    __metaclass__ = abc.ABCMeta
-
-    @abc.abstractmethod
     def _send(self):
-        pass
+        raise NotImplementedError()
 
-    @abc.abstractmethod
     def pipeline(self):
-        pass
+        raise NotImplementedError()
 
     def timer(self, stat, rate=1):
         return Timer(self, stat, rate)
@@ -213,16 +208,13 @@ class TCPStatsClient(StatsClientBase):
 
 class PipelineBase(StatsClientBase):
 
-    __metaclass__ = abc.ABCMeta
-
     def __init__(self, client):
         self._client = client
         self._prefix = client._prefix
         self._stats = deque()
 
-    @abc.abstractmethod
     def _send(self):
-        pass
+        raise NotImplementedError()
 
     def _after(self, data):
         if data is not None:


### PR DESCRIPTION
StatsClientBase and PipelineBase are not intended to be public APIs, and
the syntax for metaclasses introduces some complexity between Python 2
and 3.

Since ABCMeta and abc.abstractmethod were only being used to guarantee
that internal subclasses implemented these methods correctly, and
there's no external behavioral issues on Python 3, where the metaclass
has been ignored for years, let's remove the metaclass and rely on
NotImplementedError() and the test suite as a backstop.

Fixes #106.