### PR TITLE
Add support for timedeltas

### DIFF
--- a/docs/timing.rst
+++ b/docs/timing.rst
@@ -18,15 +18,24 @@ The simplest way to use a timer is to record the time yourself and send
 it manually, using the :ref:`timing` method::
 
     import time
+    from datetime import datetime
     from statsd import StatsClient
 
     statsd = StatsClient()
 
+    # Pass milliseconds directly
+
     start = time.time()
     time.sleep(3)
-
     # You must convert to milliseconds:
     dt = int((time.time() - start) * 1000)
+    statsd.timing('slept', dt)
+
+    # Or pass a timedelta
+
+    start = datetime.utcnow()
+    time.sleep(3)
+    dt = datetime.utcnow() - start
     statsd.timing('slept', dt)
 
 

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -41,11 +41,10 @@ class Timer(object):
         def _wrapped(*args, **kwargs):
             start_time = time_now()
             try:
-                return_value = f(*args, **kwargs)
+                return f(*args, **kwargs)
             finally:
                 elapsed_time_ms = 1000.0 * (time_now() - start_time)
                 self.client.timing(self.stat, elapsed_time_ms, self.rate)
-            return return_value
         return _wrapped
 
     def __enter__(self):

--- a/statsd/client.py
+++ b/statsd/client.py
@@ -1,5 +1,6 @@
 from __future__ import with_statement
 from collections import deque
+from datetime import timedelta
 import functools
 import random
 import socket
@@ -90,7 +91,14 @@ class StatsClientBase(object):
         return Timer(self, stat, rate)
 
     def timing(self, stat, delta, rate=1):
-        """Send new timing information. `delta` is in milliseconds."""
+        """
+        Send new timing information.
+
+        `delta` can be either a number of milliseconds or a timedelta.
+        """
+        if isinstance(delta, timedelta):
+            # Convert timedelta to number of milliseconds.
+            delta = delta.total_seconds() * 1000.
         self._send_stat(stat, '%0.6f|ms' % delta, rate)
 
     def incr(self, stat, count=1, rate=1):

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -3,6 +3,7 @@ import functools
 import random
 import re
 import socket
+from datetime import timedelta
 from unittest import SkipTest
 
 import mock
@@ -379,6 +380,17 @@ def test_timing_tcp():
     """TCPStatsClient.timing works."""
     cl = _tcp_client()
     _test_timing(cl, 'tcp')
+
+
+def test_timing_supports_timedelta():
+    cl = _udp_client()
+    proto = 'udp'
+
+    cl.timing('foo', timedelta(seconds=1.5))
+    _sock_check(cl._sock, 1, proto, 'foo:1500.000000|ms')
+
+    cl.timing('foo', timedelta(days=1.5))
+    _sock_check(cl._sock, 2, proto, 'foo:129600000.000000|ms')
 
 
 def _test_prepare(cl, proto):


### PR DESCRIPTION
Allow passing datetime.timedelta objects directly to
StatsClient.timing(), automatically converting to milliseconds.

Closes #104 