### PR TITLE
Remove refs

### DIFF
--- a/docs/configure.rst
+++ b/docs/configure.rst
@@ -12,15 +12,19 @@ Runtime
 =======
 
 If you are running the statsd_ server locally and on the default port,
-it's extremely easy::
+it's extremely easy:
+
+.. code-block:: python
 
     from statsd import StatsClient
 
     statsd = StatsClient()
     statsd.incr('foo')
 
-There are three arguments to configure your ``StatsClient`` instance.
-They, and their defaults, are::
+There are several arguments to configure your :py:class:`StatsClient` instance.
+They, and their defaults, are:
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -30,15 +34,17 @@ They, and their defaults, are::
                          maxudpsize=512,
                          ipv6=False)
 
-``host`` is the host running the statsd server. It will support any kind
-of name or IP address you might use.
+``host`` is the host running the statsd server. It will support any kind of
+name or IP address you might use.
 
-``port`` is the statsd server port. The default for both server and
-client is ``8125``.
+``port`` is the statsd server port. The default for both server and client is
+``8125``.
 
-``prefix`` helps distinguish multiple applications or environments using
-the same statsd server. It will be prepended to all stats,
-automatically. For example::
+``prefix`` helps distinguish multiple applications or environments using the
+same statsd server. It will be prepended to all stats, automatically. For
+example:
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -48,16 +54,16 @@ automatically. For example::
     foo_stats.incr('baz')
     bar_stats.incr('baz')
 
-will produce two different stats, ``foo.baz`` and ``bar.baz``. Without
-the ``prefix`` argument, or with the same ``prefix``, two
-``StatsClient`` instances will update the same stats.
+will produce two different stats, ``foo.baz`` and ``bar.baz``. Without the
+``prefix`` argument, or with the same ``prefix``, two ``StatsClient`` instances
+will update the same stats.
 
 .. versionadded:: 2.0.3
 
-``maxudpsize`` specifies the maximum packet size statsd will use. This is
-an advanced options and should not be changed unless you know what you are
-doing. Larger values then the default of 512 are generally deemed unsafe for use
-on the internet. On a controlled local network or when the statsd server is
+``maxudpsize`` specifies the maximum packet size statsd will use. This is an
+advanced options and should not be changed unless you know what you are doing.
+Larger values then the default of 512 are generally deemed unsafe for use on
+the internet. On a controlled local network or when the statsd server is
 running on 127.0.0.1 larger values can decrease the number of UDP packets when
 pipelining many metrics. Use with care!
 
@@ -79,7 +85,7 @@ TCP Clients
 
 :ref:`TCP-based clients <tcp-chapter>` have an additional ``timeout`` argument,
 which defaults to ``None``, and is passed to `settimeout
-<https://docs.python.org/2/library/socket.html#socket.socket.settimeout>`.
+<https://docs.python.org/2/library/socket.html#socket.socket.settimeout>`_.
 
 
 UnixSocket Clients
@@ -92,18 +98,23 @@ UnixSocket Clients
 In Django
 =========
 
-If you are using Statsd in a Django_ application, you can configure a
-default ``StatsClient`` in the Django settings. All of these settings
-are optional.
+If you are using Statsd in a Django_ application, you can configure a default
+:py:class:`StatsClient` in the Django settings. All of these settings are
+optional.
 
-Here are the settings and their defaults::
+Here are the settings and their defaults:
+
+.. code-block:: python
 
     STATSD_HOST = 'localhost'
     STATSD_PORT = 8125
     STATSD_PREFIX = None
     STATSD_MAXUDPSIZE = 512
+    STATSD_IPV6 = False
 
-You can use the default ``StatsClient`` simply::
+You can use the default :py:class:`StatsClient` simply:
+
+.. code-block:: python
 
     from statsd.defaults.django import statsd
 
@@ -113,17 +124,22 @@ You can use the default ``StatsClient`` simply::
 From the Environment
 ====================
 
-Statsd isn't only useful in Django or on the web. A default instance
-can also be configured via environment variables.
+StatsD isn't only useful in Django or on the web. A default instance can also
+be configured via environment variables.
 
-Here are the environment variables and their defaults::
+Here are the environment variables and their defaults:
+
+.. code-block:: bash
 
     STATSD_HOST=localhost
     STATSD_PORT=8125
     STATSD_PREFIX=None
     STATSD_MAXUDPSIZE=512
+    STATSD_IPV6=0
 
-and then in your Python application, you can simply do::
+and then in your Python application, you can simply do:
+
+.. code-block:: python
 
     from statsd.defaults.env import statsd
 
@@ -131,9 +147,8 @@ and then in your Python application, you can simply do::
 
 .. note::
 
-    As of version 3.0, this default instance is always available,
-    configured with the default values, unless overridden by the
-    environment.
+    As of version 3.0, this default instance is always available, configured
+    with the default values, unless overridden by the environment.
 
 .. _statsd: https://github.com/etsy/statsd
 .. _Django: https://www.djangoproject.com/

--- a/docs/pipeline.rst
+++ b/docs/pipeline.rst
@@ -4,12 +4,14 @@
 Pipelines
 =========
 
-The ``Pipeline`` class is a subclass of ``StatsClient`` that batches
-together several stats before sending. It implements the entire client
-interface, plus a ``send()`` method.
+The :py:class:`Pipeline` class is a subclass of :py:class:`StatsClient` that
+batches together several stats before sending. It implements the entire client
+interface, plus a :py:meth:`send() <Pipeline.send()>` method.
 
-``Pipeline`` objects should be created with
-``StatsClient().pipeline()``::
+:py:class:`Pipeline` objects should be created with
+:py:meth:`StatsClient.pipeline()`:
+
+.. code-block:: python
 
     client = StatsClient()
 
@@ -19,29 +21,30 @@ interface, plus a ``send()`` method.
     pipe.timing('baz', 520)
     pipe.send()
 
-No stats will be sent until ``send()`` is called, at which point they
-will be packed into as few UDP packets as possible.
+No stats will be sent until :py:meth:`send() <Pipeline.send()>` is called, at
+which point they will be packed into as few UDP packets as possible.
 
 
 As a Context Manager
 ====================
 
-``Pipeline`` objects can also be used as context managers::
+:py:class:`Pipeline` objects can also be used as context managers:
+
+.. code-block:: python
 
     with StatsClient().pipeline() as pipe:
         pipe.incr('foo')
         pipe.decr('bar')
 
-``pipe.send()`` will be called automatically when the managed block
+:py:meth:`Pipeline.send()` will be called automatically when the managed block
 exits.
 
 
 Thread Safety
 =============
 
-While ``StatsClient`` instances are considered thread-safe (or at least
+While :py:class:`StatsClient` instances are considered thread-safe (or at least
 as thread-safe as the standard library's ``socket.send`` is),
-``Pipeline`` instances **are not thread-safe**. Storing stats for later
-creates at least two important race conditions in a multi-threaded
-environment. You should create one ``Pipeline`` per-thread, if
-necessary.
+:py:class:`Pipeline` instances **are not thread-safe**. Storing stats for later
+creates at least two important race conditions in a multi-threaded environment.
+You should create one :py:class:`Pipeline` per-thread, if necessary.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -4,14 +4,14 @@
 API Reference
 =============
 
-The ``StatsClient`` provides accessors for all the types of data the
-statsd_ server supports.
+The ``StatsClient`` provides accessors for all the types of data the statsd_
+server supports.
 
 .. note::
 
-    Each public stats API method supports a ``rate`` parameter, but
-    statsd doesn't always use it the same way. See the
-    :ref:`types-chapter` for more information.
+    Each public stats API method supports a ``rate`` parameter, but statsd
+    doesn't always use it the same way. See the :ref:`types-chapter` for more
+    information.
 
 
 .. _StatsClient:
@@ -21,17 +21,17 @@ statsd_ server supports.
 
 .. py:class:: StatsClient(host='localhost', port=8125, prefix=None, maxudpsize=512)
 
-   Create a new ``StatsClient`` instance with the appropriate connection
-   and prefix information.
+    Create a new ``StatsClient`` instance with the appropriate connection and
+    prefix information.
 
-   :param str host: the hostname or IP address of the statsd_ server
-   :param int port: the port of the statsd server
-   :param prefix: a prefix to distinguish and group stats from an
-       application or environment
-   :type prefix: str or None
-   :param int maxudpsize: the largest safe UDP packet to send. 512 is
-       generally considered safe for the public internet, but private
-       networks may support larger packet sizes.
+    :param str host: the hostname or IP address of the statsd_ server
+    :param int port: the port of the statsd server
+    :param prefix: a prefix to distinguish and group stats from an application
+        or environment
+    :type prefix: str or None
+    :param int maxudpsize: the largest safe UDP packet to send. 512 is
+        generally considered safe for the public internet, but private networks
+        may support larger packet sizes.
 
 .. _incr:
 
@@ -40,15 +40,14 @@ statsd_ server supports.
 
 .. py:method:: StatsClient.incr(stat, count=1, rate=1)
 
-   Increment a :ref:`counter <counter-type>`.
+    Increment a :ref:`counter <counter-type>`.
 
-   :param str stat: the name of the counter to increment
-   :param int count: the amount to increment by. Typically an integer.
-       May be negative, but see also :py:meth:`decr()
-       <StatsClient.decr()>`.
-   :param float rate: a sample rate, a float between 0 and 1. Will only
-       send data this percentage of the time. The statsd server will
-       take the sample rate into account for counters.
+    :param str stat: the name of the counter to increment
+    :param int count: the amount to increment by. Typically an integer.  May be
+        negative, but see also :py:meth:`decr() <StatsClient.decr()>`.
+    :param float rate: a sample rate, a float between 0 and 1. Will only send
+        data this percentage of the time. The statsd server will take the
+        sample rate into account for counters.
 
 
 .. _decr:
@@ -58,15 +57,15 @@ statsd_ server supports.
 
 .. py:method:: StatsClient.decr(stat, count=1, rate=1)
 
-   Decrement a :ref:`counter <counter-type>`.
+    Decrement a :ref:`counter <counter-type>`.
 
-   :param str stat: the name of the counter to increment
-   :param int count: the amount to increment by. Typically an integer.
-       May be negative, but that will have the impact of incrementing
-       the counter but see also :py:meth:`incr() <StatsClient.incr()>`.
-   :param float rate: a sample rate, a float between 0 and 1. Will only
-       send data this percentage of the time. The statsd server will
-       take the sample rate into account for counters
+    :param str stat: the name of the counter to increment
+    :param int count: the amount to increment by. Typically an integer.  May be
+        negative, but that will have the impact of incrementing the counter but
+        see also :py:meth:`incr() <StatsClient.incr()>`.
+    :param float rate: a sample rate, a float between 0 and 1. Will only send
+        data this percentage of the time. The statsd server will take the
+        sample rate into account for counters
 
 
 .. _gauge:
@@ -76,23 +75,20 @@ statsd_ server supports.
 
 .. py:method:: StatsClient.gauge(stat, value, rate=1, delta=False)
 
-   Set a :ref:`gauge <gauge-type>` value.
+    Set a :ref:`gauge <gauge-type>` value.
 
-   :param str stat: the name of the gauge to set
-   :param value: the current value of the gauge
-   :type value: int or float
-   :param float rate: a sample rate, a float between 0 and 1. Will only
-       send data this percentage of the time. The statsd server does
-       *not* take the sample rate into account for gauges. Use with care
-   :param bool delta: whether or not to consider this a delta value or
-       an absolute value. See the :ref:`gauge <gauge-type>` type for
-       more detail
+    :param str stat: the name of the gauge to set
+    :param value: the current value of the gauge
+    :type value: int or float
+    :param float rate: a sample rate, a float between 0 and 1. Will only send
+        data this percentage of the time. The statsd server does *not* take the
+        sample rate into account for gauges. Use with care
+    :param bool delta: whether or not to consider this a delta value or an
+        absolute value. See the :ref:`gauge <gauge-type>` type for more detail
 
 .. note::
 
-   Gauges were added to the statsd server in version 0.1.1. If you try
-   to use this method with an older version of the server, the data will
-   not be recorded.
+    Gauges were added to the statsd server in version 0.1.1.
 
 .. note::
 
@@ -106,19 +102,17 @@ statsd_ server supports.
 
 .. py:method:: StatsClient.set(stat, value, rate=1)
 
-   Increment a :ref:`set <set-type>` value.
+    Increment a :ref:`set <set-type>` value.
 
-   :param str stat: the name of the set to update
-   :param value: the unique value to count
-   :param float rate: a sample rate, a float between 0 and 1. Will only
-       send data this percentage of the time. The statsd server does
-       *not* take the sample rate into account for sets. Use with care.
+    :param str stat: the name of the set to update
+    :param value: the unique value to count
+    :param float rate: a sample rate, a float between 0 and 1. Will only send
+        data this percentage of the time. The statsd server does *not* take the
+        sample rate into account for sets. Use with care.
 
 .. note::
 
-   Sets were added to the statsd server in version 0.6.0. If you
-   try to use this method with an older version of the server, the
-   data will not be recorded.
+   Sets were added to the statsd server in version 0.6.0.
 
 
 .. _timing:
@@ -128,15 +122,16 @@ statsd_ server supports.
 
 .. py:method:: StatsClient.timing(stat, delta, rate=1)
 
-   Record :ref:`timer <timer-type>` information.
+    Record :ref:`timer <timer-type>` information.
 
-   :param str stat: the name of the timer to use
-   :param delta: the number of milliseconds whatever action took. 
-       ``datetime.timedelta`` objects will be converted to milliseconds
-   :type delta: int or float or datetime.timedelta
-   :param float rate: a sample rate, a float between 0 and 1. Will only
-       send data this percentage of the time. The statsd server does
-       *not* take the sample rate into account for timers.
+    :param str stat: the name of the timer to use
+    :param delta: the number of milliseconds whatever action took.
+        :py:class:`datetime.timedelta` objects will be converted to
+        milliseconds
+    :type delta: int or float or datetime.timedelta
+    :param float rate: a sample rate, a float between 0 and 1. Will only send
+        data this percentage of the time. The statsd server does *not* take the
+        sample rate into account for timers.
 
 
 .. _timer:
@@ -146,15 +141,14 @@ statsd_ server supports.
 
 .. py:method:: StatsClient.timer(stat, rate=1)
 
-   Return a :py:class:`Timer` object that can be used as a context
-   manager or decorator to automatically record timing for a block or
-   function call. See also the :ref:`chapter on timing
-   <timing-chapter>`.
+    Return a :py:class:`Timer` object that can be used as a context manager or
+    decorator to automatically record timing for a block or function call. See
+    also the :ref:`chapter on timing <timing-chapter>`.
 
-   :param str stat: the name of the timer to use
-   :param float rate: a sample rate, a float between 0 and 1. Will only
-       send data this percentage of the time. The statsd server does
-       *not* take the sample rate into account for timers.
+    :param str stat: the name of the timer to use
+    :param float rate: a sample rate, a float between 0 and 1. Will only send
+        data this percentage of the time. The statsd server does *not* take the
+        sample rate into account for timers.
 
 .. code-block:: python
 
@@ -186,13 +180,13 @@ statsd_ server supports.
 
 .. py:class:: Timer()
 
-   The :ref:`Timer objects <timer-object>` returned by
-   :py:meth:`StatsClient.timer()`. These should never be
-   instantiated directly.
+    The :ref:`Timer objects <timer-object>` returned by
+    :py:meth:`StatsClient.timer()`. These should never be instantiated
+    directly.
 
-:py:class:`Timer` objects should not be shared between threads (except
-when used as decorators, which is thread-safe) but could be used within
-another context manager or decorator. For example:
+:py:class:`Timer` objects should not be shared between threads (except when
+used as decorators, which is thread-safe) but could be used within another
+context manager or decorator. For example:
 
 .. code-block:: python
 
@@ -216,9 +210,9 @@ another context manager or decorator. For example:
 
 .. py:method:: Timer.start()
 
-   Causes a timer object to start counting. Called automatically when
-   the object is used as a decorator or context manager. Returns the
-   timer object for simplicity.
+    Causes a timer object to start counting. Called automatically when the
+    object is used as a decorator or context manager. Returns the timer object
+    for simplicity.
 
 
 .. _timer-stop:
@@ -228,16 +222,15 @@ another context manager or decorator. For example:
 
 .. py:method:: Timer.stop(send=True)
 
-   Causes the timer object to stop timing and send the results to
-   statsd_.  Can be called with ``send=False`` to prevent immediate
-   sending immediately, and use :py:meth:`send() <Timer.send()>`. Called
-   automatically when the object is used as a decorator or context
-   manager. Returns the timer object.
+    Causes the timer object to stop timing and send the results to statsd_.
+    Can be called with ``send=False`` to prevent immediate sending immediately,
+    and use :py:meth:`send() <Timer.send()>`. Called automatically when the
+    object is used as a decorator or context manager. Returns the timer object.
 
-   If ``stop()`` is called before :py:meth:`start() <Timer.start()>`, a
-   ``RuntimeError`` is raised.
+    If ``stop()`` is called before :py:meth:`start() <Timer.start()>`, a
+    ``RuntimeError`` is raised.
 
-   :param bool send: Whether to automatically send the results
+    :param bool send: Whether to automatically send the results
 
 .. code-block:: python
 
@@ -252,9 +245,8 @@ another context manager or decorator. For example:
 
 .. py:method:: Timer.send()
 
-   Causes the timer to send any unsent data. If the data has already
-   been sent, or has not yet been recorded, a ``RuntimeError`` is
-   raised.
+    Causes the timer to send any unsent data. If the data has already been
+    sent, or has not yet been recorded, a ``RuntimeError`` is raised.
 
 .. code-block:: python
 
@@ -264,8 +256,7 @@ another context manager or decorator. For example:
 
 .. note::
 
-   See the note abbout :ref:`timer objects and pipelines
-   <timer-direct-note>`.
+    See the note abbout :ref:`timer objects and pipelines <timer-direct-note>`.
 
 
 .. _pipeline:
@@ -275,11 +266,19 @@ another context manager or decorator. For example:
 
 .. py:method:: StatsClient.pipeline()
 
-   Returns a :py:class:`Pipeline` object for collecting several stats.
-   Can also be used as a context manager::
+    Returns a :py:class:`Pipeline` object for collecting several stats.  Can
+    also be used as a context manager.
 
-    with StatsClient().pipeline() as pipe:
-        pipe.incr('foo')
+.. code-block:: python
+
+    pipe = StatsClient().pipeline()
+    pipe.incr('foo')
+    pipe.send()
+
+    # or
+
+    with StatsClient().pipeline as pipe:
+        pipe.incr('bar')
 
 
 .. _Pipeline:
@@ -289,13 +288,12 @@ another context manager or decorator. For example:
 
 .. py:class:: Pipeline()
 
-   A :ref:`Pipeline <pipeline-chapter>` object that can be used to
-   collect and send several stats at once. Useful for reducing network
-   traffic and speeding up instrumentation under certain loads. Can be
-   used as a context manager.
+    A :ref:`Pipeline <pipeline-chapter>` object that can be used to collect and
+    send several stats at once. Useful for reducing network traffic and
+    speeding up instrumentation under certain loads. Can be used as a context
+    manager.
 
-   Pipeline extends :py:class:`StatsClient` and has all associated
-   methods.
+    Pipeline extends :py:class:`StatsClient` and has all associated methods.
 
 .. code-block:: python
 
@@ -303,9 +301,10 @@ another context manager or decorator. For example:
     pipe.incr('foo')
     pipe.send()
 
+    # or
+
     with StatsClient().pipeline as pipe:
         pipe.incr('bar')
-
 
 .. _pipeline-send:
 
@@ -314,13 +313,8 @@ another context manager or decorator. For example:
 
 .. py:method:: Pipeline.send()
 
-   Causes the :py:class:`Pipeline` object to send all batched stats in
-   as few packets as possible.
-
-.. note::
-
-   This method is not implemented on the base :py:class:`StatsClient`
-   class.
+    Causes the :py:class:`Pipeline` object to send all batched stats in as few
+    packets as possible.
 
 
 .. _TCPStatsClient:
@@ -330,26 +324,25 @@ another context manager or decorator. For example:
 
 .. py:class:: TCPStatsClient(host='localhost', port=8125, prefix=None, timeout=None, ipv6=False)
 
-   Create a new ``TCPStatsClient`` instance with the appropriate connection
-   and prefix information.
+    Create a new ``TCPStatsClient`` instance with the appropriate connection
+    and prefix information.
 
-   :param str host: the hostname or IP address of the statsd_ server
-   :param int port: the port of the statsd server
-   :param prefix: a prefix to distinguish and group stats from an
-       application or environment.
-   :type prefix: str or None
-   :param float timeout: socket timeout for any actions on the
-       connection socket.
+    :param str host: the hostname or IP address of the statsd_ server
+    :param int port: the port of the statsd server
+    :param prefix: a prefix to distinguish and group stats from an application
+        or environment.
+    :type prefix: str or None
+    :param float timeout: socket timeout for any actions on the connection
+        socket.
 
 
-``TCPStatsClient`` implements all methods of :py:class:`StatsClient`,
-including :py:meth:`pipeline() <StatsClient.pipeline>`, with the
-difference that it is not thread safe and it can raise exceptions on
-connection errors. Unlike :py:class:`StatsClient` it uses a TCP
-connection to communicate with StatsD.
+``TCPStatsClient`` implements all methods of :py:class:`StatsClient`, including
+:py:meth:`pipeline() <StatsClient.pipeline>`, with the difference that it is
+not thread safe and it can raise exceptions on connection errors. Unlike
+:py:class:`StatsClient` it uses a TCP connection to communicate with StatsD.
 
-In addition to the stats methods, ``TCPStatsClient`` supports the
-following TCP-specific methods.
+In addition to the stats methods, ``TCPStatsClient`` supports the following
+TCP-specific methods.
 
 
 .. _tcp_close:
@@ -359,9 +352,9 @@ following TCP-specific methods.
 
 .. py:method:: TCPStatsClient.close()
 
-   Closes a connection that's currently open and deletes it's socket. If
-   this is called on a :py:class:`TCPStatsClient` which currently has no
-   open connection it is a non-action.
+    Closes a connection that's currently open and deletes it's socket. If this
+    is called on a :py:class:`TCPStatsClient` which currently has no open
+    connection it is a non-action.
 
 .. code-block:: python
 
@@ -379,12 +372,11 @@ following TCP-specific methods.
 
 .. py:method:: TCPStatsClient.connect()
 
-   Creates a connection to StatsD. If there are errors like connection
-   timed out or connection refused, the according exceptions will be
-   raised. It is usually not necessary to call this method because
-   sending data to StatsD will call ``connect`` implicitely if the
-   current instance of :py:class:`TCPStatsClient` does not already hold
-   an open connection.
+    Creates a connection to StatsD. If there are errors like connection timed
+    out or connection refused, the according exceptions will be raised. It is
+    usually not necessary to call this method because sending data to StatsD
+    will call ``connect`` implicitely if the current instance of
+    :py:class:`TCPStatsClient` does not already hold an open connection.
 
 .. code-block:: python
 
@@ -403,11 +395,11 @@ following TCP-specific methods.
 
 .. py:method:: TCPStatsClient.reconnect()
 
-   Closes a currently existing connection and replaces it with a new
-   one.  If no connection exists already it will simply create a new
-   one.  Internally this does nothing else than calling
-   :py:meth:`close() <TCPStatsClient.close()>` and :py:meth:`connect()
-   <TCPStatsClient.connect()>`.
+    Closes a currently existing connection and replaces it with a new one.  If
+    no connection exists already it will simply create a new one.  Internally
+    this does nothing else than calling :py:meth:`close()
+    <TCPStatsClient.close()>` and :py:meth:`connect()
+    <TCPStatsClient.connect()>`.
 
 .. code-block:: python
 
@@ -425,15 +417,15 @@ following TCP-specific methods.
 
 .. py:class:: UnixSocketStatsClient(socket_path, prefix=None, timeout=None)
 
-   A version of :py:class:`StatsClient` that communicates over Unix
-   sockets. It implements all methods of :py:class:`StatsClient`.
+    A version of :py:class:`StatsClient` that communicates over Unix sockets.
+    It implements all methods of :py:class:`StatsClient`.
 
-   :param str socket_path: the path to the (writeable) Unix socket
-   :param prefix: a prefix to distinguish and group stats from an
-       application or environment
-   :type prefix: str or None
-   :param float timeout: socket timeout for any actions on the
-       connection socket.
+    :param str socket_path: the path to the (writeable) Unix socket
+    :param prefix: a prefix to distinguish and group stats from an application
+        or environment
+    :type prefix: str or None
+    :param float timeout: socket timeout for any actions on the connection
+        socket.
 
 
 .. _statsd: https://github.com/etsy/statsd

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,11 +14,6 @@ server supports.
     information.
 
 
-.. _StatsClient:
-
-``StatsClient``
-===============
-
 .. py:class:: StatsClient(host='localhost', port=8125, prefix=None, maxudpsize=512)
 
     Create a new ``StatsClient`` instance with the appropriate connection and
@@ -33,11 +28,6 @@ server supports.
         generally considered safe for the public internet, but private networks
         may support larger packet sizes.
 
-.. _incr:
-
-``incr``
---------
-
 .. py:method:: StatsClient.incr(stat, count=1, rate=1)
 
     Increment a :ref:`counter <counter-type>`.
@@ -48,12 +38,6 @@ server supports.
     :param float rate: a sample rate, a float between 0 and 1. Will only send
         data this percentage of the time. The statsd server will take the
         sample rate into account for counters.
-
-
-.. _decr:
-
-``decr``
---------
 
 .. py:method:: StatsClient.decr(stat, count=1, rate=1)
 
@@ -66,12 +50,6 @@ server supports.
     :param float rate: a sample rate, a float between 0 and 1. Will only send
         data this percentage of the time. The statsd server will take the
         sample rate into account for counters
-
-
-.. _gauge:
-
-``gauge``
----------
 
 .. py:method:: StatsClient.gauge(stat, value, rate=1, delta=False)
 
@@ -94,12 +72,6 @@ server supports.
 
     Gauge deltas were added to the statsd server in version 0.6.0.
 
-
-.. _set:
-
-``set``
----------
-
 .. py:method:: StatsClient.set(stat, value, rate=1)
 
     Increment a :ref:`set <set-type>` value.
@@ -114,12 +86,6 @@ server supports.
 
    Sets were added to the statsd server in version 0.6.0.
 
-
-.. _timing:
-
-``timing``
-----------
-
 .. py:method:: StatsClient.timing(stat, delta, rate=1)
 
     Record :ref:`timer <timer-type>` information.
@@ -132,12 +98,6 @@ server supports.
     :param float rate: a sample rate, a float between 0 and 1. Will only send
         data this percentage of the time. The statsd server does *not* take the
         sample rate into account for timers.
-
-
-.. _timer:
-
-``timer``
-=========
 
 .. py:method:: StatsClient.timer(stat, rate=1)
 
@@ -172,11 +132,21 @@ server supports.
     def bar():
         pass
 
+.. py:method:: StatsClient.pipeline()
 
-.. _timer-class:
+    Returns a :py:class:`Pipeline` object for collecting several stats.  Can
+    also be used as a context manager.
 
-``Timer``
-=========
+.. code-block:: python
+
+    pipe = StatsClient().pipeline()
+    pipe.incr('foo')
+    pipe.send()
+
+    # or
+
+    with StatsClient().pipeline as pipe:
+        pipe.incr('bar')
 
 .. py:class:: Timer()
 
@@ -202,23 +172,11 @@ context manager or decorator. For example:
 :py:class:`Timer` objects may be reused by calling :py:meth:`start()
 <Timer.start()>` again.
 
-
-.. _timer-start:
-
-``start``
----------
-
 .. py:method:: Timer.start()
 
     Causes a timer object to start counting. Called automatically when the
     object is used as a decorator or context manager. Returns the timer object
     for simplicity.
-
-
-.. _timer-stop:
-
-``stop``
---------
 
 .. py:method:: Timer.stop(send=True)
 
@@ -237,12 +195,6 @@ context manager or decorator. For example:
     timer = StatsClient().timer('foo').start()
     timer.stop()
 
-
-.. _timer-send:
-
-``send``
---------
-
 .. py:method:: Timer.send()
 
     Causes the timer to send any unsent data. If the data has already been
@@ -257,34 +209,6 @@ context manager or decorator. For example:
 .. note::
 
     See the note abbout :ref:`timer objects and pipelines <timer-direct-note>`.
-
-
-.. _pipeline:
-
-``pipeline``
-============
-
-.. py:method:: StatsClient.pipeline()
-
-    Returns a :py:class:`Pipeline` object for collecting several stats.  Can
-    also be used as a context manager.
-
-.. code-block:: python
-
-    pipe = StatsClient().pipeline()
-    pipe.incr('foo')
-    pipe.send()
-
-    # or
-
-    with StatsClient().pipeline as pipe:
-        pipe.incr('bar')
-
-
-.. _Pipeline:
-
-``Pipeline``
-============
 
 .. py:class:: Pipeline()
 
@@ -306,21 +230,10 @@ context manager or decorator. For example:
     with StatsClient().pipeline as pipe:
         pipe.incr('bar')
 
-.. _pipeline-send:
-
-``send``
---------
-
 .. py:method:: Pipeline.send()
 
     Causes the :py:class:`Pipeline` object to send all batched stats in as few
     packets as possible.
-
-
-.. _TCPStatsClient:
-
-``TCPStatsClient``
-==================
 
 .. py:class:: TCPStatsClient(host='localhost', port=8125, prefix=None, timeout=None, ipv6=False)
 
@@ -335,7 +248,6 @@ context manager or decorator. For example:
     :param float timeout: socket timeout for any actions on the connection
         socket.
 
-
 ``TCPStatsClient`` implements all methods of :py:class:`StatsClient`, including
 :py:meth:`pipeline() <StatsClient.pipeline>`, with the difference that it is
 not thread safe and it can raise exceptions on connection errors. Unlike
@@ -343,12 +255,6 @@ not thread safe and it can raise exceptions on connection errors. Unlike
 
 In addition to the stats methods, ``TCPStatsClient`` supports the following
 TCP-specific methods.
-
-
-.. _tcp_close:
-
-``close``
----------
 
 .. py:method:: TCPStatsClient.close()
 
@@ -363,12 +269,6 @@ TCP-specific methods.
     statsd = TCPStatsClient()
     statsd.incr('some.event')
     statsd.close()
-
-
-.. _tcp_connect:
-
-``connect``
------------
 
 .. py:method:: TCPStatsClient.connect()
 
@@ -387,12 +287,6 @@ TCP-specific methods.
     statsd.close()
     statsd.connect()  # creates new connection
 
-
-.. _tcp_reconnect:
-
-``reconnect``
--------------
-
 .. py:method:: TCPStatsClient.reconnect()
 
     Closes a currently existing connection and replaces it with a new one.  If
@@ -408,12 +302,6 @@ TCP-specific methods.
     statsd = TCPStatsClient()
     statsd.incr('some.event')
     statsd.reconnect()  # closes open connection and creates new one
-
-
-.. _UnixSocketStatsClient:
-
-``UnixSocketStatsClient``
-=========================
 
 .. py:class:: UnixSocketStatsClient(socket_path, prefix=None, timeout=None)
 

--- a/docs/tcp.rst
+++ b/docs/tcp.rst
@@ -4,31 +4,21 @@
 TCPStatsClient
 ==============
 
-.. py:class:: TCPStatsClient(host='localhost', port=8125, prefix=None, timeout=None, ipv6=False)
-
-   :param str host: The hostname of the StatsD server
-   :param int port: The port number of the StatsD server
-   :param prefix: The stat name prefix
-   :type prefix: str or None
-   :param timeout: The TCP socket timeout
-   :type timeout: number or None
-   :param bool ipv6: Use IPv6 for server name resolution
-
 .. code-block:: python
 
     statsd = TCPStatsClient(host='1.2.3.4', port=8126, timeout=1.)
 
-The ``TCPStatsClient`` class has a very similar interface to
-``StatsClient``, but internally it uses TCP connections instead of UDP.
-These are the main differencies when using ``TCPStatsClient`` compared
-to ``StatsClient``:
+The :py:class:`TCPStatsClient` class has a very similar interface to
+:py:class:`StatsClient`, but internally it uses TCP connections instead of UDP.
+These are the main differences when using ``TCPStatsClient`` compared to
+``StatsClient``:
 
-* The constructor supports a ``timeout`` parameter to set a timeout on
-  all socket actions.
+* The constructor supports a ``timeout`` parameter to set a timeout on all
+  socket actions.
 
-* ``connect()`` and all methods that send data can potentially raise
-  socket exceptions.
+* :py:meth:`connect() <TCPStatsClient.connect()>` and all methods that send
+  data can potentially raise socket exceptions.
 
 * **It is not thread-safe**, so it is recommended to not share it across
-  threads unless a lot of attention is paid to make sure that no two
-  threads ever use it at once.
+  threads unless a lot of attention is paid to make sure that no two threads
+  ever use it at once.

--- a/docs/timing.rst
+++ b/docs/timing.rst
@@ -15,7 +15,9 @@ Calling ``timing`` manually
 ===========================
 
 The simplest way to use a timer is to record the time yourself and send
-it manually, using the :ref:`timing` method::
+it manually, using the :py:meth:`StatsClient.timing()` method:
+
+.. code-block:: python
 
     import time
     from datetime import datetime
@@ -44,10 +46,13 @@ it manually, using the :ref:`timing` method::
 Using a context manager
 =======================
 
-Each ``StatsClient`` instance contains a :ref:`timer` attribute that can
-be used as a context manager or a decorator. When used as a context
-manager, it will automatically report the time taken for the inner
-block::
+The :py:meth:`StatsClient.timer()` method will return a :py:class:`Timer`
+object that can be used as both a context manager and a thread-safe decorator.
+
+When used as a context manager, it will automatically report the time taken for
+the inner block:
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -65,11 +70,11 @@ block::
 Using a decorator
 =================
 
-The ``timer`` attribute decorates your methods in a thread-safe manner.
-Every time the decorated function is called, the time it took to execute
-will be sent to the statsd server.
+:py:class:`Timer` objects can be used to decorate a method in a thread-safe
+manner.  Every time the decorated function is called, the time it took to
+execute will be sent to the statsd server.
 
-::
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -92,11 +97,10 @@ Using a Timer object directly
 
 .. versionadded:: 2.1
 
-:py:class:`statsd.client.Timer` objects function as context managers and
-as decorators, but they can also be used directly. (Flat is, after all,
-better than nested.)
+:py:class:`Timer` objects function as context managers and as decorators, but
+they can also be used directly. (Flat is, after all, better than nested.)
 
-::
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -107,44 +111,45 @@ better than nested.)
     # Do something fun.
     foo_timer.stop()
 
-When :py:meth:`statsd.client.Timer.stop` is called, a :ref:`timing stat
-<timer-type>` will automatically be sent to StatsD. You can over ride
-this behavior with the ``send=False`` keyword argument to ``stop()``::
+When :py:meth:`Timer.stop()` is called, a :ref:`timing stat <timer-type>` will
+automatically be sent to StatsD. You can over ride this behavior with the
+``send=False`` keyword argument to :py:meth:`stop() <Timer.stop()>`:
+
+.. code-block:: python
 
     foo_timer.stop(send=False)
     foo_timer.send()
 
-Use :py:meth:`statsd.client.Timer.send` to send the stat when you're
-ready.
+Use :py:meth:`Timer.send()` to send the stat when you're ready.
 
 .. _timer-direct-note:
 
 .. note::
-   This use of timers is compatible with :ref:`Pipelines
-   <pipeline-chapter>` but the ``send()`` method may not behave exactly
-   as expected. Timing data *must* be sent, either by calling ``stop()``
-   without ``send=False`` or calling ``send()`` explicitly, in order for
-   it to be included in the pipeline. However, it will *not* be sent
-   immediately.
 
-.. code-block:: python
+    This use of timers is compatible with :ref:`Pipelines <pipeline-chapter>`
+    but the ``send()`` method may not behave exactly as expected. Timing data
+    *must* be sent, either by calling ``stop()`` without ``send=False`` or
+    calling ``send()`` explicitly, in order for it to be included in the
+    pipeline. However, it will *not* be sent immediately.
 
-    with statsd.pipeline() as pipe:
-        foo_timer = pipe.timer('foo').start()
-        # Do something...
-        pipe.incr('bar')
-        foo_timer.stop()  # Will be sent when the managed block exits.
+    .. code-block:: python
 
-    with statsd.pipeline() as pipe:
-        foo_timer = pipe.timer('foo').start()
-        # Do something...
-        pipe.incr('bar')
-        foo_timer.stop(send=False)  # Will not be sent.
-        foo_timer.send()  # Will be sent when the managed block exits.
-        # Do something else...
+        with statsd.pipeline() as pipe:
+            foo_timer = pipe.timer('foo').start()
+            # Do something...
+            pipe.incr('bar')
+            foo_timer.stop()  # Will be sent when the managed block exits.
 
-    with statsd.pipeline() as pipe:
-        foo_timer = pipe.timer('foo').start()
-        pipe.incr('bar')
-        # Do something...
-        foo_timer.stop(send=False)  # Data will _not_ be sent
+        with statsd.pipeline() as pipe:
+            foo_timer = pipe.timer('foo').start()
+            # Do something...
+            pipe.incr('bar')
+            foo_timer.stop(send=False)  # Will not be sent.
+            foo_timer.send()  # Will be sent when the managed block exits.
+            # Do something else...
+
+        with statsd.pipeline() as pipe:
+            foo_timer = pipe.timer('foo').start()
+            pipe.incr('bar')
+            # Do something...
+            foo_timer.stop(send=False)  # Data will _not_ be sent

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -4,14 +4,14 @@
 Data Types
 ==========
 
-The statsd_ server supports a number of different data types, and
-performs different aggregation on each of them. The three main types are
-*counters*, *timers*, and *gauges*.
+The statsd_ server supports a number of different data types, and performs
+different aggregation on each of them. The three main types are *counters*,
+*timers*, and *gauges*.
 
 The statsd server collects and aggregates in 30 second intervals before
-flushing to Graphite_. Graphite usually stores the most recent data in
-1-minute averaged buckets, so when you're looking at a graph, for each
-stat you are typically seeing the average value over that minute.
+flushing to Graphite_. Graphite usually stores the most recent data in 1-minute
+averaged buckets, so when you're looking at a graph, for each stat you are
+typically seeing the average value over that minute.
 
 
 .. _counter-type:
@@ -19,16 +19,17 @@ stat you are typically seeing the average value over that minute.
 Counters
 ========
 
-*Counters* are the most basic and default type. They are treated as a
-count of a type of event per second, and are, in Graphite_, typically
-averaged over one minute. That is, when looking at a graph, you are
-usually seeing the average number of events per second during a
-one-minute period.
+*Counters* are the most basic and default type. They are treated as a count of
+a type of event per second, and are, in Graphite_, typically averaged over one
+minute. That is, when looking at a graph, you are usually seeing the average
+number of events per second during a one-minute period.
 
 The statsd server collects counters under the ``stats`` prefix.
 
-Counters are managed with the :ref:`incr` and :ref:`decr` methods of
-``StatsClient``::
+Counters are managed with the :py:meth:`StatsClient.incr()` and
+:py:meth:`StatsClient.decr()` methods:
+
+.. code-block:: python
 
     from statsd import StatsClient
 
@@ -36,27 +37,31 @@ Counters are managed with the :ref:`incr` and :ref:`decr` methods of
 
     statsd.incr('some.event')
 
-You can increment a counter by more than one by passing a second
-parameter::
+You can increment a counter by more than one by passing a second parameter:
+
+.. code-block:: python
 
     statsd.incr('some.other.event', 10)
 
-You can also use the ``rate`` parameter to produce sampled data. The
-statsd server will take the sample rate into account, and the
-``StatsClient`` will only send data ``rate`` percent of the time. This
-can help the statsd server stay responsive with extremely busy
-applications.
+You can also use the ``rate`` parameter to produce sampled data. The statsd
+server will take the sample rate into account, and the :py:class:`StatsClient`
+will only send data ``rate`` percent of the time. This can help the statsd
+server stay responsive with extremely busy applications.
 
-``rate`` is a float between 0 and 1::
+``rate`` is a float between 0 and 1:
+
+.. code-block:: python
 
     # Increment this counter 10% of the time.
     statsd.incr('some.third.event', rate=0.1)
 
-Because the statsd server is aware of the sampling, it will still show
-you the true average rate per second.
+Because the statsd server is aware of the sampling, it will still show you the
+true average rate per second.
 
-You can also decrement counters. The ``decr`` method takes the same
-arguments as ``incr``::
+You can also decrement counters. The :py:meth:`StatsClient.decr()` method takes
+the same arguments as ``incr``:
+
+.. code-block:: python
 
     statsd.decr('some.other.event')
     # Decrease the counter by 5, 15% sample.
@@ -68,40 +73,40 @@ arguments as ``incr``::
 Timers
 ======
 
-*Timers* are meant to track how long something took. They are an
-invaluable tool for tracking application performance.
+*Timers* are meant to track how long something took. They are an invaluable
+tool for tracking application performance.
 
-The statsd server collects all timers under the ``stats.timers`` prefix,
-and will calculate the lower bound, mean, 90th percentile, upper bound,
-and count of each timer for each period (by the time you see it in
-Graphite, that's usually per minute).
+The statsd server collects all timers under the ``stats.timers`` prefix, and
+will calculate the lower bound, mean, 90th percentile, upper bound, and count
+of each timer for each period (by the time you see it in Graphite, that's
+usually per minute).
 
-* The *lower bound* is the lowest value statsd saw for that stat during
-  that time period.
+* The *lower bound* is the lowest value statsd saw for that stat during that
+  time period.
 
-* The *mean* is the average of all values statsd saw for that stat 
-  during that time period.
+* The *mean* is the average of all values statsd saw for that stat during that
+  time period.
 
-* The *90th percentile* is a value *x* such that 90% of all the values
-  statsd saw for that stat during that time period are below *x*, and
-  10% are above.  This is a great number to try to optimize.
+* The *90th percentile* is a value *x* such that 90% of all the values statsd
+  saw for that stat during that time period are below *x*, and 10% are above.
+  This is a great number to try to optimize.
 
-* The *upper bound* is the highest value statsd saw for that stat during
-  that time period.
+* The *upper bound* is the highest value statsd saw for that stat during that
+  time period.
 
-* The *count* is the number of timings statsd saw for that stat during
-  that time period. It is not averaged.
+* The *count* is the number of timings statsd saw for that stat during that
+  time period. It is not averaged.
 
-The statsd server only operates in millisecond timings. Everything
-should be converted to milliseconds.
+The statsd server only operates in millisecond timings. Everything should be
+converted to milliseconds.
 
-The ``rate`` parameter will sample the data being sent to the statsd
-server, but in this case it doesn't make sense for the statsd server to
-take it into account (except possibly for the *count* value, but then it
-would be lying about how much data it averaged).
+The ``rate`` parameter will sample the data being sent to the statsd server,
+but in this case it doesn't make sense for the statsd server to take it into
+account (except possibly for the *count* value, but then it would be lying
+about how much data it averaged).
 
-See the :ref:`timing documentation <timing-chapter>` for more detail on
-using timers with Statsd.
+See the :ref:`timing documentation <timing-chapter>` for more detail on using
+timers with Statsd.
 
 
 .. _gauge-type:
@@ -109,28 +114,29 @@ using timers with Statsd.
 Gauges
 ======
 
-*Gauges* are a constant data type. They are not subject to averaging,
-and they don't change unless you change them. That is, once you set a
-gauge value, it will be a flat line on the graph until you change it
-again.
+*Gauges* are a constant data type. They are not subject to averaging, and they
+don't change unless you change them. That is, once you set a gauge value, it
+will be a flat line on the graph until you change it again.
 
-Gauges are useful for things that are already averaged, or don't need to
-reset periodically. System load, for example, could be graphed with a
-gauge. You might use ``incr`` to count the number of logins to a system,
-but a gauge to track how many active WebSocket connections you have.
+Gauges are useful for things that are already averaged, or don't need to reset
+periodically. System load, for example, could be graphed with a gauge. You
+might use :py:meth:`StatsClient.incr` to count the number of logins to a
+system, but a gauge to track how many active WebSocket connections you have.
 
 The statsd server collects gauges under the ``stats.gauges`` prefix.
 
-The :ref:`gauge` method also support the ``rate`` parameter to sample
-data back to the statsd server, but use it with care, especially with
+The :py:meth:`StatsClient.gauge` method also support the ``rate`` parameter to
+sample data back to the statsd server, but use it with care, especially with
 gauges that may not be updated very often.
 
 
 Gauge Deltas
 ------------
 
-Gauges may be *updated* (as opposed to *set*) by setting the ``delta``
-keyword argument to ``True``. For example::
+Gauges may be *updated* (as opposed to *set*) by setting the ``delta`` keyword
+argument to ``True``. For example:
+
+.. code-block:: python
 
     statsd.gauge('foo', 70)  # Set the 'foo' gauge to 70.
     statsd.gauge('foo', 1, delta=True)  # Set 'foo' to 71.
@@ -138,27 +144,25 @@ keyword argument to ``True``. For example::
 
 .. note::
 
-   Support for gauge deltas was added to the server in 3eecd18_. You
-   will need to be running at least that version for the ``delta`` kwarg
-   to have any effect.
+    Support for gauge deltas was added to the server in 0.6.0. 
 
 
 .. _set-type:
 
 Sets
-======
+====
 
 *Sets* count the number of unique values passed to a key.
 
-For example, you could count the number of users accessing your system
-using:
+For example, you could count the number of users accessing your system using:
+
+.. code-block:: python
 
     statsd.set('users', userid)
 
-If that method is called multiple times with the same userid in the
-same sample period, that userid will only be counted once.
+If that method is called multiple times with the same userid in the same sample
+period, that userid will only be counted once.
 
 
 .. _statsd: https://github.com/etsy/statsd
 .. _Graphite: https://graphite.readthedocs.io
-.. _3eecd18: https://github.com/etsy/statsd/commit/3eecd18

--- a/docs/types.rst
+++ b/docs/types.rst
@@ -160,8 +160,8 @@ For example, you could count the number of users accessing your system using:
 
     statsd.set('users', userid)
 
-If that method is called multiple times with the same userid in the same sample
-period, that userid will only be counted once.
+If :py:meth:`StatsClient.set()` is called multiple times with the same userid
+in the same sample period, that userid will only be counted once.
 
 
 .. _statsd: https://github.com/etsy/statsd

--- a/docs/unix_socket.rst
+++ b/docs/unix_socket.rst
@@ -4,22 +4,14 @@
 UnixSocketStatsClient
 =====================
 
-.. py:class:: UnixSocketStatsClient(socket_path, prefix=None, timeout=None)
-
-   :param string socket_path: The path to the Unix socket
-   :param prefix: The stat name prefix
-   :type prefix: str or None
-   :param timeout: The TCP socket timeout
-   :type timeout: number or None
-
 .. code-block:: python
 
     statsd = UnixSocketStatsClient(socket_path='/var/run/stats.sock')
 
-The ``UnixSocketStatsClient`` class has a very similar interface to
-``TCPStatsClient``, but internally it uses Unix Domain sockets instead
-of TCP.  These are the main differences when using
-``UnixSocketStatsClient`` compared to ``StatsClient``:
+The :py:class:`UnixSocketStatsClient` class has a very similar interface to
+:py:class:`TCPStatsClient`, but internally it uses Unix Domain sockets instead
+of TCP.  These are the main differences when using ``UnixSocketStatsClient``
+compared to ``StatsClient``:
 
 * The ``socket_path`` parameter is required. It has no default.
 


### PR DESCRIPTION
There were a lot of duplicative headings and reference points in the `reference.rst` doc. This updates things to point to the new, domain-specific directives, then removes the redundancy.