### PR TITLE
Add a Unix socket version of the default (UDP) client.

### DIFF
--- a/statsd/client/udp.py
+++ b/statsd/client/udp.py
@@ -48,3 +48,14 @@ class StatsClient(StatsClientBase):
 
     def pipeline(self):
         return Pipeline(self)
+
+
+class UnixSocketStatsClient(StatsClient):
+    """Unix domain socket version of the UDP StatsClient."""
+
+    def __init__(self, socket_path, prefix=None, maxudpsize=512):
+        """Create a new client."""
+        self._addr = socket_path
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        self._prefix = prefix
+        self._maxudpsize = maxudpsize


### PR DESCRIPTION
howdy! I've reopened https://github.com/jsocol/pystatsd/issues/127 and included this PR as a reference implementation. 

Turns out, while the unix socket stream client is great if your statsd server is listening on TCP, but unfortunately it doesn't work for the AF_UNIX + UDP use case.

This PR just adds an additional client to the statsd.client.udp namespace that satisfies the missing use case. I borrowed the same name as the stream client, but I could see that being confusing. Open to suggestion!

edit; I also haven't written tests yet, as I think the naming of the class should probably be nailed down first. If you think this change is good, I'll add test cases for the new client