### PR TITLE
Add `close()` method to UDP client

### DIFF
--- a/statsd/client/udp.py
+++ b/statsd/client/udp.py
@@ -46,5 +46,10 @@ class StatsClient(StatsClientBase):
             # No time for love, Dr. Jones!
             pass
 
+    def close(self):
+        if self._sock and hasattr(self._sock, 'close'):
+            self._sock.close()
+        self._sock = None
+
     def pipeline(self):
         return Pipeline(self)


### PR DESCRIPTION
Unlike its stream counterpart, the UDP client does not have a "close()"
method. This means there is no public API to clean up the socket,
resulting in a `ResourceWarning`.