### PR TITLE
Add `close()` method to UDP client

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -28,6 +28,10 @@ server supports.
         generally considered safe for the public internet, but private networks
         may support larger packet sizes.
 
+.. py:method:: StatsClient.close()
+
+    Close the underlying UDP socket.
+
 .. py:method:: StatsClient.incr(stat, count=1, rate=1)
 
     Increment a :ref:`counter <counter-type>`.

--- a/statsd/client/base.py
+++ b/statsd/client/base.py
@@ -10,6 +10,10 @@ from .timer import Timer
 class StatsClientBase(object):
     """A Base class for various statsd clients."""
 
+    def close(self):
+        """Used to close and clean up any underlying resources."""
+        raise NotImplementedError()
+
     def _send(self):
         raise NotImplementedError()
 

--- a/statsd/client/udp.py
+++ b/statsd/client/udp.py
@@ -46,5 +46,10 @@ class StatsClient(StatsClientBase):
             # No time for love, Dr. Jones!
             pass
 
+    def close(self):
+        if self._sock and hasattr(self._sock, 'close'):
+            self._sock.close()
+        self._sock = None
+
     def pipeline(self):
         return Pipeline(self)


### PR DESCRIPTION
Unlike its stream counterpart, the UDP client does not have a "close()"
method. This means there is no public API to clean up the socket,
resulting in a `ResourceWarning`.

Fixes #136.