### PR TITLE
GitHub Action to run tox tests

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,27 +1,12 @@
 name: tox
 on: [push, pull_request]
 jobs:
-  tox-jobs:
-    strategy:
-      fail-fast: false
-      matrix:
-        job: [lint, docs-lint, pycodestyle]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: 3.x
-      - run: pip install --upgrade pip
-      - run: pip install tox
-      - run: tox -e ${{ matrix.job }}
-
   tox:
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
-        python: ['3.7', '3.8', '3.9', '3.10', '3.11-dev', 'pypy-3.9']
+        python: ['3.7', '3.8', '3.9', 'pypy-3.9']  # Nose fails on Python 3.10+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -1,0 +1,33 @@
+name: tox
+on: [push, pull_request]
+jobs:
+  tox-jobs:
+    strategy:
+      fail-fast: false
+      matrix:
+        job: [lint, docs-lint, pycodestyle]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e ${{ matrix.job }}
+
+  tox:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]  # [macos-latest, ubuntu-latest, windows-latest]
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11-dev', 'pypy-3.9']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - run: pip install --upgrade pip
+      - run: pip install tox
+      - run: tox -e py

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37
+envlist = py37,py38,py39,py310,py311,pypy3
 
 [testenv]
 deps=
-    mock==1.0.1
-    nose==1.2.1
-    coverage==3.5.2
+    mock
+    nose
+    coverage
 
 commands=
     nosetests statsd --with-coverage --cover-package=statsd []


### PR DESCRIPTION
Because Travis CI is on an [extended vacation](https://travis-ci.org/github/jsocol/pystatsd/builds).

Test results: https://github.com/cclauss/pystatsd-1/actions

Nose fails on Python 3.10 and higher.
* Consider using https://github.com/pytest-dev/nose2pytest