### PR TITLE
Replace nose with nose2

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -25,12 +25,12 @@ necessary.
 Running Tests
 =============
 
-To run the tests, you just need ``nose`` and ``mock``. These can be
-installed with ``pip``::
+To run the tests, you just need ``nose2``. This can be installed with
+``pip``::
 
     $ mkvirtualenv statsd
     $ pip install -r requirements.txt
-    $ nosetests
+    $ nose2
 
 You can also run the tests with tox::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mock==1.0.1
-nose==1.2.1
-flake8==1.7.0
+nose2
+flake8
+coverage

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     package_data={'': ['README.rst']},
-    test_suite='nose.collector',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -4,10 +4,7 @@ import random
 import re
 import socket
 from datetime import timedelta
-from unittest import SkipTest
-
-import mock
-from nose.tools import eq_
+from unittest import SkipTest, mock
 
 from statsd import StatsClient
 from statsd import TCPStatsClient
@@ -32,6 +29,10 @@ make_val = {
     'tcp': lambda x, addr: mock.call(str.encode(x + '\n')),
     'unix': lambda x, addr: mock.call(str.encode(x + '\n')),
 }
+
+
+def eq_(a, b, msg=None):
+    assert a == b, msg
 
 
 def _udp_client(prefix=None, addr=None, port=None, ipv6=False):

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,8 @@ envlist = py37,py38,py39,py310,py311,pypy3
 
 [testenv]
 deps=
-    mock
-    nose
+    nose2
     coverage
 
 commands=
-    nosetests statsd --with-coverage --cover-package=statsd []
+    nose2 statsd --with-coverage


### PR DESCRIPTION
Nose stopped getting updates around 2015. Nose2 is is the continued
evolution of that project. Ultimately, this library's test suite is
simple enough to move toward pure unittest, but that will require a
larger refactor to wrap everything in unittest.TestCase.
