### PR TITLE
Remove __future__ imports

### DIFF
--- a/statsd/__init__.py
+++ b/statsd/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from .client import StatsClient
 from .client import TCPStatsClient
 from .client import UnixSocketStatsClient

--- a/statsd/client/__init__.py
+++ b/statsd/client/__init__.py
@@ -1,4 +1,2 @@
-from __future__ import absolute_import, division, unicode_literals
-
 from .stream import TCPStatsClient, UnixSocketStatsClient  # noqa
 from .udp import StatsClient  # noqa

--- a/statsd/client/base.py
+++ b/statsd/client/base.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import random
 from collections import deque
 from datetime import timedelta

--- a/statsd/client/stream.py
+++ b/statsd/client/stream.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import socket
 
 from .base import StatsClientBase, PipelineBase

--- a/statsd/client/timer.py
+++ b/statsd/client/timer.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import functools
 
 # Use timer that's not susceptible to time of day adjustments.

--- a/statsd/client/udp.py
+++ b/statsd/client/udp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, unicode_literals
-
 import socket
 
 from .base import StatsClientBase, PipelineBase

--- a/statsd/defaults/django.py
+++ b/statsd/defaults/django.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.conf import settings
 
 from statsd import defaults

--- a/statsd/defaults/env.py
+++ b/statsd/defaults/env.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 
 from statsd import defaults

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -1,4 +1,3 @@
-from __future__ import with_statement
 import functools
 import random
 import re


### PR DESCRIPTION
All of the features from __future__ that were in this library have been
in Python since 3.0. Now that Python 2 is no longer supported, we no
longer need them.
