### PR TITLE
Fix linting in CI for real

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
   lint:
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v
+      - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
           python-version: '3.11'


### PR DESCRIPTION
This is what I get for enabling auto-merge before making lint a required
status check.
