### PR TITLE
Update CHANGELOG ahead of 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
-Statsd Changelog
-================
+# Statsd Changelog
+
+## Unreleased
+
+### Added
+
+- Updates support to Python 3.7 through 3.11.
+- Added `close()` method to UDP-based `StatsClient`. (#136)
+
+### Dropped
+
+- Drops support for Python 2.
 
 Version 3.3
 -----------


### PR DESCRIPTION
Moves the CHANGES file to CHANGELOG.md, and updates it for the v4.0
release.
