### PR TITLE
Fix timing decorator for async functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 - Drops support for Python 2.
 
+### Fixed
+
+- Using a timing decorator on an async function should now properly measure the
+  execution time, instead of counting immediately. See #119.
+
 Version 3.3
 -----------
 


### PR DESCRIPTION
Well I sat on this for long enough that it got easier: async/await is no
longer a syntax error in any supported version of Python. That meant
that it was relatively straightforward to apply @nkonin's proposed patch
from #119.

Fixes #119.
