### PR TITLE
CI: Replace flake8 with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python }}
 
   lint:
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
 
@@ -31,6 +31,6 @@ jobs:
       with:
         python-version: '3.11'
 
-    - run: pip install flake8
+    - run: pip install ruff
 
-    - run: flake8 statsd
+    - run: ruff statsd

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -64,11 +64,11 @@ PEP8 and PyFlakes
 =================
 
 The development requirements (``requirements.txt``) include the
-``flake8`` tool. It is easy to run::
+``ruff`` tool. It is easy to run::
 
-    $ flake8 statsd/
+    $ ruff statsd/
 
-``flake8`` should not raise any issues or warnings.
+``ruff`` should not raise any issues or warnings.
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,42 @@ urls = {Homepage = "https://github.com/jsocol/pystatsd"}
 [tool.distutils.bdist_wheel]
 universal = 1
 
+[tool.ruff]
+ignore = [
+    "PT008",
+    "SIM102",
+    "SIM105",
+    "SIM117",
+    "UP032"
+]
+select = [
+    "B",
+    "BLE",
+    "C4",
+    "DTZ",
+    "E",
+    "T10",
+    "EXE",
+    "F",
+    "G",
+    "ICN",
+    "INP",
+    "ISC",
+    "PIE",
+    "PLC",
+    "PLE",
+    "PLE",
+    "PTH",
+    "RUF",
+    "SIM",
+    "UP",
+    "W",
+]
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 10
+
 [tool.setuptools]
 include-package-data = true
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-nose2
-flake8
 coverage
+nose2
+ruff

--- a/statsd/tests.py
+++ b/statsd/tests.py
@@ -1027,7 +1027,7 @@ def test_pipeline_packet_size():
     """Pipelines shouldn't send packets larger than 512 bytes (UDP only)."""
     sc = _udp_client()
     pipe = sc.pipeline()
-    for x in range(32):
+    for _ in range(32):
         # 32 * 16 = 512, so this will need 2 packets.
         pipe.incr('sixteen_char_str')
     pipe.send()


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including flake8, isort, pylint, and pyupgrade and is written in Rust for speed.