### PR TITLE
Fix/130 ignore socket errors

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -14,7 +14,7 @@ server supports.
     information.
 
 
-.. py:class:: StatsClient(host='localhost', port=8125, prefix=None, maxudpsize=512)
+.. py:class:: StatsClient(host='localhost', port=8125, prefix=None, maxudpsize=512, ignore_socket_errors=False)
 
     Create a new ``StatsClient`` instance with the appropriate connection and
     prefix information.
@@ -27,10 +27,21 @@ server supports.
     :param int maxudpsize: the largest safe UDP packet to send. 512 is
         generally considered safe for the public internet, but private networks
         may support larger packet sizes.
+    :param bool ignore_socket_errors: whether or not to ignore socket errors
+        when initializing the client. If set to ``True``, the client will ignore
+        the error and continue. If set to ``False``, the client will raise the error.
+        You can check the ``is_ready`` attribute to see if the client is ready to send.
 
 .. py:method:: StatsClient.close()
 
     Close the underlying UDP socket.
+
+.. py:method:: StatsClient.reset()
+
+    Resets the underlying UDP socket. This is useful if the connection is
+    not ready due to network issues or if the connection was closed. This
+    method will honor the ``ignore_socket_errors`` parameter in the constructor.
+    You can check the ``is_ready`` attribute to see if the client is ready to send.
 
 .. py:method:: StatsClient.incr(stat, count=1, rate=1)
 

--- a/statsd/client/base.py
+++ b/statsd/client/base.py
@@ -8,6 +8,15 @@ from .timer import Timer
 class StatsClientBase:
     """A Base class for various statsd clients."""
 
+    @property
+    def is_ready(self):
+        """Returns True if the client is ready to send data."""
+        raise NotImplementedError()
+
+    def reset(self):
+        """Reset the client."""
+        raise NotImplementedError()
+
     def close(self):
         """Used to close and clean up any underlying resources."""
         raise NotImplementedError()

--- a/statsd/client/stream.py
+++ b/statsd/client/stream.py
@@ -18,6 +18,9 @@ class StreamClientBase(StatsClientBase):
             self._sock.close()
         self._sock = None
 
+    def reset(self):
+        self.reconnect()
+
     def reconnect(self):
         self.close()
         self.connect()
@@ -48,6 +51,11 @@ class TCPStatsClient(StreamClientBase):
         self._prefix = prefix
         self._sock = None
 
+    @property
+    def is_ready(self):
+        """Return True if the client is ready to send data."""
+        return self._sock is not None
+
     def connect(self):
         fam = socket.AF_INET6 if self._ipv6 else socket.AF_INET
         family, _, _, _, addr = socket.getaddrinfo(
@@ -66,6 +74,11 @@ class UnixSocketStatsClient(StreamClientBase):
         self._timeout = timeout
         self._prefix = prefix
         self._sock = None
+
+    @property
+    def is_ready(self):
+        """Return True if the client is ready to send data."""
+        return self._sock is not None
 
     def connect(self):
         self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)

--- a/statsd/client/udp.py
+++ b/statsd/client/udp.py
@@ -26,15 +26,39 @@ class StatsClient(StatsClientBase):
     """A client for statsd."""
 
     def __init__(self, host='localhost', port=8125, prefix=None,
-                 maxudpsize=512, ipv6=False):
+                 maxudpsize=512, ipv6=False, ignore_socket_errors=False):
         """Create a new client."""
-        fam = socket.AF_INET6 if ipv6 else socket.AF_INET
-        family, _, _, _, addr = socket.getaddrinfo(
-            host, port, fam, socket.SOCK_DGRAM)[0]
-        self._addr = addr
-        self._sock = socket.socket(family, socket.SOCK_DGRAM)
+        self._host = host
+        self._port = port
+        self._ipv6 = ipv6
         self._prefix = prefix
         self._maxudpsize = maxudpsize
+        self._addr = None
+        self._sock = None
+        self._ignore_socket_errors = ignore_socket_errors
+        self._ready = False
+        self._open()
+
+    @property
+    def is_ready(self):
+        """Return True if the client is ready to send data."""
+        return self._ready
+
+    def _open(self):
+        fam = socket.AF_INET6 if self._ipv6 else socket.AF_INET
+
+        try:
+            family, _, _, _, addr = socket.getaddrinfo(
+                self._host, self._port, fam, socket.SOCK_DGRAM)[0]
+            self._addr = addr
+            self._sock = socket.socket(family, socket.SOCK_DGRAM)
+            self._prefix = self._prefix
+            self._maxudpsize = self._maxudpsize
+            self._ready = True
+        except (socket.gaierror, OSError):
+            if not self._ignore_socket_errors:
+                raise
+            self._ready = False
 
     def _send(self, data):
         """Send data to statsd."""
@@ -43,6 +67,10 @@ class StatsClient(StatsClientBase):
         except (OSError, RuntimeError):
             # No time for love, Dr. Jones!
             pass
+
+    def reset(self):
+        self.close()
+        self._open()
 
     def close(self):
         if self._sock and hasattr(self._sock, 'close'):


### PR DESCRIPTION
This PR adds a way to ignore the dreaded `socket.gaierror` error when initializing the UDP client and a server is missing.

- Fixes https://github.com/jsocol/pystatsd/issues/130
- (Hopefully) fixes https://github.com/jsocol/pystatsd/issues/125

### Details

The new constructor signature is:

```python
StatsClient(host='localhost', port=8125, prefix=None, maxudpsize=512, ignore_socket_errors=False)
```

To complement this flag, I added the `is_ready` property and the `reset()` method to clients.

On the UDP client:

- By default, the client will work as usual. When passing `ignore_socket_errors=True`, errors during the socket initialization will be ignored.
- The `is_ready` property will reflect the state after the initialization.
- In order to be able to recover from a failed initialization you can use the `reset()` method.

On streaming clients:

- They will work as usual (won't ignore errors)
- `is_ready` reflects the current status of the inner socket.
- `reset()` calls `reconnect()` under the hood.
