### PR TITLE
Update installation instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Or from source::
 
     $ git clone https://github.com/jsocol/pystatsd
     $ cd pystatsd
-    $ python setup.py install
+    $ pip install .
 
 
 Docs


### PR DESCRIPTION
The project now uses a modern version of setuptools which do not include a `setup.py` any more.

Updated installations instructions to reflect these changes.

fixes #189